### PR TITLE
Support mqtts://

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,12 @@ the line in the file to be sure the right line is changed.
 
 MQTT is configured using the _mqtt.conf_ file. The following properties are supported:
 
-| Property | Description                                         | Example                       |
-| -------- | --------------------------------------------------- | ----------------------------- |
-| uri      | Required. The address of the MQTT server.           | `"http://192.168.1.100:1883"` |
-| username | Optional. The username to log into the server with. | `"mqttuser"`                  |
-| password | Optional. The password to log into the server with. | `"mqttpass"`                  |
+| Property           | Description                                                                                                                                                                                               | Example                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| uri                | Required. The address of the MQTT server.                                                                                                                                                                 | `"mqtt://192.168.1.100:1883"` |
+| username           | Optional. The username to log into the server with.                                                                                                                                                       | `"mqttuser"`                  |
+| password           | Optional. The password to log into the server with.                                                                                                                                                       | `"mqttpass"`                  |
+| rejectUnauthorized | Optional. Default true. Controls whether connections to mqtts:// servers should allow self-signed certificates. Set to false if your MQTT certificates are self-signed and are getting connection errors. | `false`                       |
 
 The only authentication method currently supported is basic.
 

--- a/sampleConfiguration/mqtt.json
+++ b/sampleConfiguration/mqtt.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/danecreekphotography/node-deepstackai-trigger/master/src/schemas/mqttManagerConfiguration.schema.json",
-  "uri": "http://mqtt:1883",
+  "uri": "mqtt://mqtt:1883",
   "username": "user",
   "password": "pass"
 }

--- a/src/handlers/mqttManager/IMqttManagerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttManagerConfigJson.ts
@@ -6,4 +6,5 @@ export default interface IMqttManagerConfigJson {
   uri: string;
   username: string;
   password: string;
+  rejectUnauthorized: boolean;
 }

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -1,21 +1,21 @@
+import MQTT from 'async-mqtt';
+import { promises as fsPromise } from 'fs';
 import * as JSONC from 'jsonc-parser';
+
 import * as log from '../../Log';
+import mqttManagerConfigurationSchema from '../../schemas/mqttManagerConfiguration.schema.json';
+import validateJsonAgainstSchema from '../../schemaValidator';
+import Trigger from '../../Trigger';
 import IDeepStackPrediction from '../../types/IDeepStackPrediction';
 import IMqttManagerConfigJson from './IMqttManagerConfigJson';
-import MQTT from 'async-mqtt';
-import mqttManagerConfigurationSchema from '../../schemas/mqttManagerConfiguration.schema.json';
-import Trigger from '../../Trigger';
-import validateJsonAgainstSchema from '../../schemaValidator';
-import { promises as fsPromise } from 'fs';
+
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Neil Enns. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-
 let isEnabled = false;
 let mqttClient: MQTT.AsyncClient;
-let mqttUri: string;
 
 /**
  * Takes a path to a configuration file and loads all of the triggers from it.
@@ -40,19 +40,18 @@ export async function loadConfiguration(configFilePath: string): Promise<void> {
 
   log.info("MQTT manager", `Loaded configuration from ${configFilePath}`);
 
-  mqttUri = mqttConfigJson.uri;
-
   try {
-    mqttClient = await MQTT.connectAsync(mqttUri, {
+    mqttClient = await MQTT.connectAsync(mqttConfigJson.uri, {
       username: mqttConfigJson.username,
       password: mqttConfigJson.password,
       clientId: "node-deepstackai-trigger",
+      rejectUnauthorized: mqttConfigJson.rejectUnauthorized ?? true,
     });
   } catch (e) {
     throw new Error(`[MQTT Manager] Unable to connect: ${e.message}`);
   }
 
-  log.info("MQTT Manager", `Connected to MQTT server ${mqttUri}`);
+  log.info("MQTT Manager", `Connected to MQTT server ${mqttConfigJson.uri}`);
   isEnabled = true;
 }
 

--- a/src/schemas/mqttManagerConfiguration.schema.json
+++ b/src/schemas/mqttManagerConfiguration.schema.json
@@ -20,6 +20,12 @@
       "description": "The password to connect with.",
       "type": "string",
       "examples": ["pass"]
+    },
+    "rejectUnauthorized": {
+      "description": "Controls whether connections to mqtts:// servers should allow self-signed certificates. Set to false if your MQTT certificates are self-signed and are getting connection errors.",
+      "type": "boolean",
+      "default": true,
+      "examples": ["false"]
     }
   }
 }


### PR DESCRIPTION
Fixes #39

Confirmed this connects successfully to mqtts://test.mosquitto.org:8883, but only if the new `rejectUnauthorized` config is set to `false`, which is how it should work.
