### PR TITLE
Fixed typo in MQTT Manager log message

### DIFF
--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -127,7 +127,7 @@ function parseConfigFile(rawConfig: string): IMqttManagerConfigJson {
   if (parseErrors && parseErrors.length > 0) {
     throw new Error(
       `[MQTT Manager] Unable to load configuration file: ${parseErrors
-        .map(error => log.error("Trigger manager", `${error?.error}`))
+        .map(error => log.error("MQTT manager", `${error?.error}`))
         .join("\n")}`,
     );
   }


### PR DESCRIPTION
Fixes #48 

Changed the log error message from "Trigger manager" to "MQTT manager".