### PR TITLE
Add fileName and baseFileName to MQTT messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 1.0.1
+
+- MQTT messages now inclue a fileName and baseFileName property.
+  Technically this is a breaking change since it moves the predictions
+  to a predictions property too.
+
 ## Version 1.0.0
 
 - Released 2020-05-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Detects motion using DeepStack AI and calls registered triggers based on trigger rules.",
   "main": "dist/src/main.js",
   "files": [

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -1,6 +1,7 @@
 import MQTT from 'async-mqtt';
 import { promises as fsPromise } from 'fs';
 import * as JSONC from 'jsonc-parser';
+import path from 'path';
 
 import * as log from '../../Log';
 import mqttManagerConfigurationSchema from '../../schemas/mqttManagerConfiguration.schema.json';
@@ -75,7 +76,16 @@ export async function processTrigger(
 
   // Even though this only calls one topic the way this gets used elsewhere
   // the expectation is it returns an array.
-  return [await mqttClient.publish(trigger.mqttConfig.topic, JSON.stringify(predictions))];
+  return [
+    await mqttClient.publish(
+      trigger.mqttConfig.topic,
+      JSON.stringify({
+        fileName: fileName,
+        baseFileName: path.basename(fileName),
+        predictions,
+      }),
+    ),
+  ];
 }
 
 /**

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -80,8 +80,8 @@ export async function processTrigger(
     await mqttClient.publish(
       trigger.mqttConfig.topic,
       JSON.stringify({
-        fileName: fileName,
-        baseFileName: path.basename(fileName),
+        fileName,
+        basename: path.basename(fileName),
         predictions,
       }),
     ),


### PR DESCRIPTION
# Fixes #52 

## Description of changes

Include the image filename and basename in the MQTT messages for use later by other systems.

Note that this moves the list of predictions into a `predictions` property too.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [x] CHANGELOG.md updated
- [x] `npm version` run
