### PR TITLE
Remove typescript import sorter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,12 +26,11 @@
 
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-	"dbaeumer.vscode-eslint",
-	"davidanson.vscode-markdownlint",
-	"esbenp.prettier-vscode",
-	"mike-co.import-sorter",
-	"github.vscode-pull-request-github"
-],
+    "dbaeumer.vscode-eslint",
+    "davidanson.vscode-markdownlint",
+    "esbenp.prettier-vscode",
+    "github.vscode-pull-request-github"
+  ],
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": []


### PR DESCRIPTION
Fixes #60

## Description of changes

Removed the typescript import sorter extension from devconfig.json. Good riddance.

## Checklist

Not applicable, dev tooling only change.