### PR TITLE
Add timestamp to log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 1.1.2
+
+- Add timestamp to log messages
+
 ## Version 1.1.1
 
 - Added two optional dependencies to resolve build warnings

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -7,7 +7,8 @@
 // Everywhere else console.log() is a build breaking error to prevent
 // accidental use of it.
 /* eslint-disable no-console */
-import chalk from "chalk";
+import chalk from 'chalk';
+import moment from 'moment';
 
 /**
  * Formats a message for output to the logs.
@@ -15,7 +16,7 @@ import chalk from "chalk";
  * @param message The message
  */
 function formatMessage(source: string, message: string) {
-  return `[${source}] ${message}`;
+  return `${moment().format()} [${source}] ${message}`;
 }
 
 /**


### PR DESCRIPTION
Fixes #71 

## Description of changes

Add a timestamp to the log messages. Oh look, the moment.js library appears!

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] CHANGELOG.md updated
- [X] `npm version` run
