### PR TITLE
Disabling telegram prevents startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 1.1.3
+
+- Resolve an issue where disabling Telegram prevented startup
+
 ## Version 1.1.2
 
 - Add timestamp to log messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Detects motion using DeepStack AI and calls registered triggers based on trigger rules.",
   "main": "dist/src/main.js",
   "files": [

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -7,8 +7,8 @@
 // Everywhere else console.log() is a build breaking error to prevent
 // accidental use of it.
 /* eslint-disable no-console */
-import chalk from 'chalk';
-import moment from 'moment';
+import chalk from "chalk";
+import moment from "moment";
 
 /**
  * Formats a message for output to the logs.

--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -107,12 +107,6 @@ async function readRawConfigFile(configFilePath: string): Promise<string> {
     return null;
   });
 
-  // This shouldn't happen. Keeping the check here in case it does in the real world
-  // and someone reports things not working.
-  if (!rawConfig) {
-    throw new Error(`[Telegram Manager] Unable to load configuration file ${configFilePath}.`);
-  }
-
   return rawConfig;
 }
 


### PR DESCRIPTION
Fixes #78

## Description of changes

Removed the exception that fired on an empty `rawConfig`. Just return it as null, it's fine.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] CHANGELOG.md updated
- [X] `npm version` run
