### PR TITLE
Fixed typo in mqtt manager log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 1.1.4
+
+- Changed the log error message from "Trigger manager" to "MQTT manager" in MqttManager.ts.
+
 ## Version 1.1.3
 
 - Resolve an issue where disabling Telegram prevented startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 1.1.4
 
-- Changed the log error message from "Trigger manager" to "MQTT manager" in MqttManager.ts.
+- Fixed a bug where MQTT log messages contained "Trigger" as the message tag.
 
 ## Version 1.1.3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Detects motion using DeepStack AI and calls registered triggers based on trigger rules.",
   "main": "dist/src/main.js",
   "files": [

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -137,7 +137,7 @@ function parseConfigFile(rawConfig: string): IMqttManagerConfigJson {
   if (parseErrors && parseErrors.length > 0) {
     throw new Error(
       `[MQTT Manager] Unable to load configuration file: ${parseErrors
-        .map(error => log.error("Trigger manager", `${error?.error}`))
+        .map(error => log.error("MQTT manager", `${error?.error}`))
         .join("\n")}`,
     );
   }


### PR DESCRIPTION
# Fixes #48 

## Description of changes
Changed the log error message from "Trigger manager" to "MQTT manager".

## Checklist

- [x] CHANGELOG.md updated
- [x] `npm version` run
