### PR TITLE
Get rid of auto-tag creation in `npm version` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "npm run lint",
     "preversion": "npm run lint",
-    "postversion": "git push && git push --tags",
+    "postversion": "git push",
     "version": "npm run format && git add -A src",
     "start": "node dist/src/main.js",
     "webpack": "npx webpack --mode=production",


### PR DESCRIPTION
Fixes #85

## Description of changes

Remove the call to `git tag` from `package.json`. It'll get managed manually from now on via administrators of the project.

## Checklist

Not applicable, dev tooling change only.

If your change touches anything under src or the README.md file
these items must be done:

- [ ] CHANGELOG.md updated
- [ ] `npm version` run
