### PR TITLE
Fix telegram bot warning during jest tests

### DIFF
--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -6,3 +6,6 @@
 // and some dependency somewhere uses request-promise.
 // See https://github.com/request/request-promise/issues/247.
 jest.mock("request-promise");
+
+// Ensure there's no warning from the telegram bot module.
+process.env.NTBA_FIX_319 = "true";


### PR DESCRIPTION
Fixes #113

## Description of changes

Add the magic environment variable to jest test setup.

## Checklist

Not applicable, dev changes only.