### PR TITLE
Add checks for undefined and null to isRegisteredForObject()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Address a warning during config file validation ([issue 123](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/123)).
 - Document the available Docker image tags ([issue 128](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/128)).
+- Addresses code cleanup [issue 136](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/136).
 
 ## Version 1.5.0
 

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -210,17 +210,17 @@ export default class Trigger {
    * @returns True if the trigger is activated by the label
    */
   public isRegisteredForObject(fileName: string, label: string): boolean {
-    const isRegistered = this.watchObjects.includes(label);
+    const isRegistered = this.watchObjects?.includes(label);
     if (!isRegistered) {
       log.info(
         `Trigger ${this.name}`,
-        `${fileName}: Detected object ${label} is not in the watch objects list [${this.watchObjects.join(", ")}]`,
+        `${fileName}: Detected object ${label} is not in the watch objects list [${this.watchObjects?.join(", ")}]`,
       );
     } else {
       log.info(`Trigger ${this.name}`, `${fileName}: Matched triggering object ${label}`);
     }
 
-    return isRegistered;
+    return isRegistered ?? false;
   }
 
   /**

--- a/tests/handlers/Trigger.test.ts
+++ b/tests/handlers/Trigger.test.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import Trigger from "../../src/Trigger";
+
+test("Verify isRegisteredForObject()", () => {
+  // Empty constructor should default to enabled true
+  const trigger = new Trigger();
+  trigger.name = "Trigger.test.ts";
+
+  trigger.watchObjects = ["dog"];
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(true);
+
+  trigger.watchObjects = [];
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(false);
+
+  trigger.watchObjects = undefined;
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(false);
+
+  trigger.watchObjects = null;
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(false);
+
+  trigger.watchObjects = ["DoG"];
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(false);
+
+  trigger.watchObjects = ["dog"];
+  expect(trigger.isRegisteredForObject("unit test", "doG")).toBe(false);
+
+  trigger.watchObjects = ["cat", "elephant"];
+  expect(trigger.isRegisteredForObject("unit test", "dog")).toBe(false);
+});


### PR DESCRIPTION
# Fixes #136

## Description of changes

Add checks for undefined and null to isRegisteredForObject().

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
