### PR TITLE
Add "state": "on" to the MQTT messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a `"state": "on"` property to the MQTT messages sent on motion detection. This
+  makes it easier to build binary motion sensors based on the MQTT messages in Home Assistant
+  by using `value_template: 'value_json.state'` and `off_delay`. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139).
+
 ## Version 1.6.0
 
 - watchObjects is now case insensitive when comparing against the matched objects ([issue 134](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/134))

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -103,6 +103,7 @@ export async function processTrigger(
         fileName,
         basename: path.basename(fileName),
         predictions,
+        state: "on",
       }),
     ),
   ];


### PR DESCRIPTION
Fixes #139

## Description of changes

- Add `"state": "on"` to the MQTT messages.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md