### PR TITLE
Send state: off messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## Unreleased
+## Version 1.7.0
 
-- Add a `"state"` property to the MQTT messages sent on motion detection. This
+- Add a `state` property to the MQTT messages sent on motion detection. This
   makes it easier to build binary motion sensors based on the MQTT messages in Home Assistant
   by using `value_template: 'value_json.state'`. The delay before sending an `off` state is
   configurable with the new `offDelay` setting on `mqtt` triggers. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139) and [issue 141](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/141).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-- Add a `"state": "on"` property to the MQTT messages sent on motion detection. This
+- Add a `"state"` property to the MQTT messages sent on motion detection. This
   makes it easier to build binary motion sensors based on the MQTT messages in Home Assistant
-  by using `value_template: 'value_json.state'` and `off_delay`. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139).
+  by using `value_template: 'value_json.state'`. The delay before sending an `off` state is
+  configurable with the new `offDelay` setting on `mqtt` triggers. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139) and [issue 141](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/141).
 
 ## Version 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add a `"state": "on"` property to the MQTT messages sent on motion detection. This
+  makes it easier to build binary motion sensors based on the MQTT messages in Home Assistant
+  by using `value_template: 'value_json.state'` and `off_delay`. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139).
+
 ## Version 1.6.0
 
 - watchObjects is now case insensitive when comparing against the matched objects ([issue 134](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/134))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-deepstackai-trigger",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Detects motion using DeepStack AI and calls registered triggers based on trigger rules.",
   "main": "dist/src/main.js",
   "files": [

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -36,7 +36,8 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog"]
         },
         "mqtt": {
-          "topic": "aimotion/triggers/dog"
+          "topic": "aimotion/triggers/dog",
+          "offDelay": 5
         },
         "telegram": {
           "chatIds": [1],

--- a/src/handlers/mqttManager/IMqttConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttConfigJson.ts
@@ -4,4 +4,5 @@
  *--------------------------------------------------------------------------------------------*/
 export default interface IMqttConfigJson {
   topic: string;
+  offDelay: number;
 }

--- a/src/handlers/mqttManager/MqttConfig.ts
+++ b/src/handlers/mqttManager/MqttConfig.ts
@@ -5,11 +5,15 @@
 export default class MqttConfig {
   public topic: string;
   public enabled: boolean;
+  public offDelay: number;
 
   constructor(init?: Partial<MqttConfig>) {
     Object.assign(this, init);
 
     // Default for enabled is true if it isn't specified in the config file
     this.enabled = init?.enabled ?? true;
+
+    // Default offDelay is 30 seconds if not specified
+    this.offDelay = init?.offDelay ?? 30;
   }
 }

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -103,6 +103,7 @@ export async function processTrigger(
         fileName,
         basename: path.basename(fileName),
         predictions,
+        state: "on",
       }),
     ),
   ];

--- a/src/schemas/mqttHandlerConfiguration.schema.json
+++ b/src/schemas/mqttHandlerConfiguration.schema.json
@@ -12,6 +12,12 @@
       "minLength": 1,
       "examples": ["aimotion/trigger/dog"]
     },
+    "offDelay": {
+      "description": "Number of seconds of no motion to wait before sending an MQTT state off message. Set to 0 to disable sending off messages. Default is 30 seconds.",
+      "type": "number",
+      "default": 30,
+      "examples": ["0", "300"]
+    },
     "enabled": {
       "description": "Enables the MQTT handler on this trigger. Default is true.",
       "type": "boolean",

--- a/tests/handlers/MqttConfig.test.ts
+++ b/tests/handlers/MqttConfig.test.ts
@@ -5,9 +5,10 @@
 import MqttConfig from "../../src/handlers/mqttManager/MqttConfig";
 
 test("Verify MQTT handler configuration", () => {
-  // Empty constructor should default to enabled true
+  // Empty constructor should default to enabled true and offDelay 30
   let config = new MqttConfig();
   expect(config.enabled).toBe(true);
+  expect(config.offDelay).toBe(30);
 
   // Undefined enabled should be true
   config = new MqttConfig({ enabled: undefined });
@@ -20,4 +21,16 @@ test("Verify MQTT handler configuration", () => {
   // Explicitly set enabled false should be false
   config = new MqttConfig({ enabled: false });
   expect(config.enabled).toBe(false);
+
+  // Undefined offDelay should default to 30
+  config = new MqttConfig({ offDelay: undefined });
+  expect(config.offDelay).toBe(30);
+
+  // 0 offDelay should be 0
+  config = new MqttConfig({ offDelay: 0 });
+  expect(config.offDelay).toBe(0);
+
+  // 60 offDelay should be 60
+  config = new MqttConfig({ offDelay: 60 });
+  expect(config.offDelay).toBe(60);
 });


### PR DESCRIPTION
# Fixes #141 

## Description of changes

Sends a state: off MQTT message after a defined amount of time has elapsed. Default is 30 seconds and can be configured using the `offDelay` setting in the trigger config file. Setting it to 0 disables the message.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
