### PR TITLE
Add MQTT LWT message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+- The MQTT overall configuration now supports specifing a topic for status messages.
+  Right now the only status message sent is an LWT message for when the system goes
+  offline. Resolves [issue 145](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
+
 ## Version 1.7.0
 
 - Add a `state` property to the MQTT messages sent on motion detection. This

--- a/sampleConfiguration/mqtt.json
+++ b/sampleConfiguration/mqtt.json
@@ -2,5 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/danecreekphotography/node-deepstackai-trigger/master/src/schemas/mqttManagerConfiguration.schema.json",
   "uri": "mqtt://mqtt:1883",
   "username": "user",
-  "password": "pass"
+  "password": "pass",
+  "statusTopic": "aimotion/status"
 }

--- a/src/handlers/mqttManager/IMqttManagerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttManagerConfigJson.ts
@@ -7,4 +7,5 @@ export default interface IMqttManagerConfigJson {
   username: string;
   password: string;
   rejectUnauthorized: boolean;
+  statusTopic: string;
 }

--- a/src/handlers/mqttManager/IMqttManagerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttManagerConfigJson.ts
@@ -7,5 +7,5 @@ export default interface IMqttManagerConfigJson {
   username: string;
   password: string;
   rejectUnauthorized: boolean;
-  statusTopic: string;
+  statusTopic?: string;
 }

--- a/src/handlers/mqttManager/MqttConfig.ts
+++ b/src/handlers/mqttManager/MqttConfig.ts
@@ -6,6 +6,7 @@ export default class MqttConfig {
   public topic: string;
   public enabled: boolean;
   public offDelay: number;
+  public statusTopic: string;
 
   constructor(init?: Partial<MqttConfig>) {
     Object.assign(this, init);

--- a/src/handlers/mqttManager/MqttConfig.ts
+++ b/src/handlers/mqttManager/MqttConfig.ts
@@ -6,7 +6,7 @@ export default class MqttConfig {
   public topic: string;
   public enabled: boolean;
   public offDelay: number;
-  public statusTopic: string;
+  public statusTopic?: string;
 
   constructor(init?: Partial<MqttConfig>) {
     Object.assign(this, init);

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -16,6 +16,8 @@ import IMqttManagerConfigJson from "./IMqttManagerConfigJson";
  *--------------------------------------------------------------------------------------------*/
 
 let isEnabled = false;
+let statusTopic = "node-deepstackai-trigger/status";
+
 let mqttClient: MQTT.AsyncClient;
 const timers = new Map<string, NodeJS.Timeout>();
 
@@ -64,11 +66,21 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
 
   log.info("MQTT manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
+  if (mqttConfigJson.statusTopic) {
+    statusTopic = mqttConfigJson.statusTopic;
+  }
+
   mqttClient = await MQTT.connectAsync(mqttConfigJson.uri, {
     username: mqttConfigJson.username,
     password: mqttConfigJson.password,
     clientId: "node-deepstackai-trigger",
     rejectUnauthorized: mqttConfigJson.rejectUnauthorized ?? true,
+    will: {
+      topic: statusTopic,
+      payload: "offline",
+      qos: 2,
+      retain: false,
+    },
   }).catch(e => {
     throw new Error(`[MQTT Manager] Unable to connect: ${e.message}`);
   });

--- a/src/schemas/mqttManagerConfiguration.schema.json
+++ b/src/schemas/mqttManagerConfiguration.schema.json
@@ -26,6 +26,12 @@
       "type": "boolean",
       "default": true,
       "examples": ["false"]
+    },
+    "statusTopic": {
+      "description": "Topic status messages are published to.",
+      "type": "string",
+      "default": "node-deepstackai-trigger/status",
+      "examples": ["aimotion/status"]
     }
   }
 }


### PR DESCRIPTION
# Fixes #145

## Description of changes

- Register a LWT message to get sent if the service goes down
- Add a config option to set the topic used by the status messages

## Checklist

- [X] User-facing change description added to unreleased section of CHANGELOG.md
