### PR TITLE
Add a verbose environment variable

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DEEPSTACK_URI=http://deepstack-ai:5000/
       - TZ=America/Los_Angeles
       - PROCESS_EXISTING_IMAGES=true
+      - VERBOSE=true
     image: node:alpine
     build:
       context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Logging level is now controlled by a `VERBOSE` environment variable. When set to `true`
+  additional logging is shown in the console. When `false` or omitted only startup and
+  successful detection messages are shown. Resolves [issue 143](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
 - The MQTT overall configuration now supports specifing a topic for status messages.
   Right now the only status message sent is an LWT message for when the system goes
   offline. Resolves [issue 145](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@
   by using `value_template: 'value_json.state'`. The delay before sending an `off` state is
   configurable with the new `offDelay` setting on `mqtt` triggers. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139) and [issue 141](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/141).
 
-- Add a `"state": "on"` property to the MQTT messages sent on motion detection. This
-  makes it easier to build binary motion sensors based on the MQTT messages in Home Assistant
-  by using `value_template: 'value_json.state'` and `off_delay`. Resolves [issue 139](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/139).
-
 ## Version 1.6.0
 
 - watchObjects is now case insensitive when comparing against the matched objects ([issue 134](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/134))

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       # Docker. Don't change this unless there is a need to talk to an
       # external DeepStack server somewhere and you know what you are doing.
       - DEEPSTACK_URI=http://deepstack-ai:5000/
+      # Comment this line out to disable verbose logging. Once the system is
+      # running well the extra logging information really isn't necessary
+      # and is nice to turn off.
+      - VERBOSE=true
 
     secrets:
       - triggers

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -10,6 +10,8 @@
 import chalk from "chalk";
 import moment from "moment";
 
+const isVerbose = process.env.VERBOSE ?? false;
+
 /**
  * Formats a message for output to the logs.
  * @param source The source of the message
@@ -25,6 +27,19 @@ function formatMessage(source: string, message: string) {
  * @param message The message
  */
 export function info(source: string, message: string): void {
+  console.log(formatMessage(source, message));
+}
+
+/**
+ * Logs a verbose message to the console. Logs nothing if VERBOSE isn't set.
+ * @param source The source of the message
+ * @param message The message
+ */
+export function verbose(source: string, message: string): void {
+  if (!isVerbose) {
+    return;
+  }
+
   console.log(formatMessage(source, message));
 }
 

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -57,7 +57,7 @@ export default class Trigger {
   }
 
   private async analyzeImage(fileName: string): Promise<IDeepStackPrediction[] | undefined> {
-    log.info(`Trigger ${this.name}`, `${fileName}: Analyzing`);
+    log.verbose(`Trigger ${this.name}`, `${fileName}: Analyzing`);
     const analysis = await analyzeImage(fileName);
 
     if (!analysis?.success) {
@@ -66,11 +66,11 @@ export default class Trigger {
     }
 
     if (analysis.predictions.length == 0) {
-      log.info(`Trigger ${this.name}`, `${fileName}: No objects detected`);
+      log.verbose(`Trigger ${this.name}`, `${fileName}: No objects detected`);
       return undefined;
     }
 
-    log.info(`Trigger ${this.name}`, `${fileName}: Found at least one object in the photo`);
+    log.verbose(`Trigger ${this.name}`, `${fileName}: Found at least one object in the photo`);
     return analysis.predictions;
   }
 
@@ -131,7 +131,7 @@ export default class Trigger {
     this.receivedDate = new Date(stats.atimeMs);
 
     if (this.receivedDate < this._initalizedTime && !this._processExisting) {
-      log.info(`Trigger ${this.name}`, `${fileName}: Skipping as it was created before the service started.`);
+      log.verbose(`Trigger ${this.name}`, `${fileName}: Skipping as it was created before the service started.`);
       return false;
     }
 
@@ -145,7 +145,7 @@ export default class Trigger {
     // This eases testing since this code only gets to this point for images
     // that arrived prior to startup when _processExisting is true.
     if (secondsSinceLastTrigger < this.cooldownTime && this.receivedDate > this._initalizedTime) {
-      log.info(
+      log.verbose(
         `Trigger ${this.name}`,
         `${fileName}: Skipping as it was received before the cooldown period of ${this.cooldownTime} seconds expired.`,
       );
@@ -171,7 +171,7 @@ export default class Trigger {
       !this.isMasked(fileName, prediction);
 
     if (!isTriggered) {
-      log.info(`Trigger ${this.name}`, `${fileName}: Not triggered by ${label} (${scaledConfidence})`);
+      log.verbose(`Trigger ${this.name}`, `${fileName}: Not triggered by ${label} (${scaledConfidence})`);
     } else {
       log.info(`Trigger ${this.name}`, `${fileName}: Triggered by ${label} (${scaledConfidence})`);
     }
@@ -195,7 +195,7 @@ export default class Trigger {
       const doesOverlap = mask.overlaps(predictionRect);
 
       if (doesOverlap) {
-        log.info(`Trigger ${this.name}`, `Prediction region ${predictionRect} blocked by trigger mask ${mask}.`);
+        log.verbose(`Trigger ${this.name}`, `Prediction region ${predictionRect} blocked by trigger mask ${mask}.`);
       }
 
       return doesOverlap;
@@ -215,12 +215,12 @@ export default class Trigger {
     });
 
     if (!isRegistered) {
-      log.info(
+      log.verbose(
         `Trigger ${this.name}`,
         `${fileName}: Detected object ${label} is not in the watch objects list [${this.watchObjects?.join(", ")}]`,
       );
     } else {
-      log.info(`Trigger ${this.name}`, `${fileName}: Matched triggering object ${label}`);
+      log.verbose(`Trigger ${this.name}`, `${fileName}: Matched triggering object ${label}`);
     }
 
     return isRegistered ?? false;
@@ -237,12 +237,12 @@ export default class Trigger {
     const meetsThreshold = confidence >= this.threshold.minimum && confidence <= this.threshold.maximum;
 
     if (!meetsThreshold) {
-      log.info(
+      log.verbose(
         `Trigger ${this.name}`,
         `${fileName}: Confidence ${confidence} wasn't between threshold ${this.threshold.minimum} and ${this.threshold.maximum}`,
       );
     } else {
-      log.info(
+      log.verbose(
         `Trigger ${this.name}`,
         `${fileName}: Confidence ${confidence} meets threshold ${this.threshold.minimum} and ${this.threshold.maximum}`,
       );
@@ -261,7 +261,7 @@ export default class Trigger {
 
     try {
       this._watcher = chokidar.watch(this.watchPattern).on("add", this.processImage.bind(this));
-      log.info(`Trigger ${this.name}`, `Listening for new images in ${this.watchPattern}`);
+      log.verbose(`Trigger ${this.name}`, `Listening for new images in ${this.watchPattern}`);
     } catch (e) {
       log.error(`Trigger ${this.name}`, `Unable to start watching for images: ${e}`);
       throw e;
@@ -279,6 +279,6 @@ export default class Trigger {
       throw e;
     });
 
-    log.info(`Trigger ${this.name}`, `Stopped listening for new images in ${this.watchPattern}`);
+    log.verbose(`Trigger ${this.name}`, `Stopped listening for new images in ${this.watchPattern}`);
   }
 }

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -99,10 +99,10 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[Trigger Manager] Invalid configuration file.");
   }
 
-  log.info("Trigger manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.verbose("Trigger manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   _triggers = triggerConfigJson.triggers.map(triggerJson => {
-    log.info("Trigger manager", `Loaded configuration for ${triggerJson.name}`);
+    log.verbose("Trigger manager", `Loaded configuration for ${triggerJson.name}`);
     const configuredTrigger = new Trigger({
       cooldownTime: triggerJson.cooldownTime,
       enabled: triggerJson.enabled ?? true, // If it isn't specified then enable the camera

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -64,7 +64,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[MQTT Manager] Invalid configuration file.");
   }
 
-  log.info("MQTT manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.verbose("MQTT manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   if (mqttConfigJson.statusTopic) {
     statusTopic = mqttConfigJson.statusTopic;
@@ -105,7 +105,7 @@ export async function processTrigger(
     return [];
   }
 
-  log.info("MQTT Manager", `${fileName}: Publishing event to ${trigger.mqttConfig.topic}`);
+  log.verbose("MQTT Manager", `${fileName}: Publishing event to ${trigger.mqttConfig.topic}`);
 
   // If an off delay is configured set up a timer to send the off message in the requested number of seconds
   if (trigger?.mqttConfig?.offDelay) {

--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -44,7 +44,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
   if (!foundLoadableFile) {
     log.warn(
       "Telegram Manager",
-      "Unable to find an Telegram configuration file. If Telegram was disabled in the Docker configuration " +
+      "Unable to find a Telegram configuration file. If Telegram was disabled in the Docker configuration " +
         "then this warning can be safely ignored. Otherwise it means something is wrong with how the " +
         "container is configured. Verify the telegram secret points to a file called telegram.json or " +
         "that the /config mount point contains a file called telegram.json.",
@@ -62,7 +62,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[Telegram Manager] Invalid configuration file.");
   }
 
-  log.info("Telegram manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.verbose("Telegram manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   telegramBot = new TelegramBot(telegramConfigJson.botToken, {
     filepath: false,
@@ -104,7 +104,7 @@ async function sendTelegramMessage(
   fileName: string,
   chatId: number,
 ): Promise<TelegramBot.Message> {
-  log.info("Telegram manager", `Sending message to ${chatId}`);
+  log.verbose("Telegram manager", `Sending message to ${chatId}`);
 
   const message = telegramBot
     .sendPhoto(chatId, await fsPromise.readFile(fileName), {
@@ -137,7 +137,7 @@ function passesCooldownTime(fileName: string, trigger: Trigger): boolean {
   const secondsSinceLastTrigger = (trigger.receivedDate.getTime() - lastTriggerTime.getTime()) / 1000;
 
   if (secondsSinceLastTrigger < trigger.telegramConfig.cooldownTime) {
-    log.info(
+    log.verbose(
       `Telegram manager`,
       `${fileName}: Skipping sending message as the cooldown period of ${trigger.telegramConfig.cooldownTime} seconds hasn't expired.`,
     );
@@ -153,7 +153,7 @@ function passesCooldownTime(fileName: string, trigger: Trigger): boolean {
  */
 function readRawConfigFile(configFilePath: string): string {
   if (!configFilePath) {
-    log.info(
+    log.verbose(
       "Telegram Manager",
       `No configuration file was specified so Telegram events won't be sent. To enable Telegram events make sure the telegram secret in the docker-compose.yaml points to a configuration file.`,
     );

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -31,7 +31,7 @@ export async function processTrigger(
  * @param uri The uri to trigger
  */
 async function callTriggerUri(fileName: string, trigger: Trigger, uri: string): Promise<void> {
-  log.info("Web request", `${fileName}: Calling trigger uri ${uri}`);
+  log.verbose("Web request", `${fileName}: Calling trigger uri ${uri}`);
   try {
     await request.get(uri);
   } catch (e) {


### PR DESCRIPTION
Fixes #143 - Add a verbose environment variables

## Description of changes

- Added `VERBOSE` as a valid environment variable to control verbose logging. This is on by default for now as it makes it easier on initial configuration to see what's going on.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
