### PR TITLE
Add support for mustache templates to webRequest URIs

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       - DEEPSTACK_URI=http://deepstack-ai:5000/
       - TZ=America/Los_Angeles
       - PROCESS_EXISTING_IMAGES=true
-      - VERBOSE=true
     image: node:alpine
     build:
       context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Mustache templates are now supported in the webRequest handler URIs. One way to use this is
-  to send memo data to BlueIris with the details of predictions that caused the trigger to fire,
+  to send additional data to BlueIris with the details of predictions that caused the trigger to fire,
   for example `"http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}`.
   See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers) for
   details on available mustache variables. Resolves [issue 148](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/148).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,21 @@
 
 ## Unreleased
 
+- A `payload` property is now supported on MQTT handler message configuration, along with support for
+  mustache templates in the payload. This makes it possible to send a precicely formatted
+  message to BlueIris that will trigger recording for a specific camera instead of having
+  to use webRequest handlers. Resolves [issue 151](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/151).
 - Mustache templates are now supported in the webRequest handler URIs. One way to use this is
   to send additional data to BlueIris with the details of predictions that caused the trigger to fire,
   for example `"http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}`.
   See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers) for
   details on available mustache variables. Resolves [issue 148](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/148).
-- Logging level is now controlled by a `VERBOSE` environment variable. When set to `true`
-  additional logging is shown in the console. When `false` or omitted only startup and
-  successful detection messages are shown. Resolves [issue 143](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
-- Add a `payload` property to MQTT handler message configuration, along with support for
-  mustache templates in the payload. This makes it possible to send a precicely formatted
-  message to BlueIris that will trigger recording for a specific camera instead of having
-  to use webRequest handlers. Resolves [issue 151](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/151).
 - The MQTT overall configuration now supports specifing a topic for status messages.
   Right now the only status message sent is a LWT message for when the system goes
   offline. Resolves [issue 145](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
+- Logging level is now controlled by a `VERBOSE` environment variable. When set to `true`
+  additional logging is shown in the console. When `false` or omitted only startup and
+  successful detection messages are shown. Resolves [issue 143](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
 
 ## Version 1.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Mustache templates are now supported in the webRequest handler URIs. One way to use this is
+  to send memo data to BlueIris with the details of predictions that caused the trigger to fire,
+  for example `"http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}`.
+  See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers) for
+  details on available mustache variables. Resolves [issue 148](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/148).
 - Logging level is now controlled by a `VERBOSE` environment variable. When set to `true`
   additional logging is shown in the console. When `false` or omitted only startup and
   successful detection messages are shown. Resolves [issue 143](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@
 - Logging level is now controlled by a `VERBOSE` environment variable. When set to `true`
   additional logging is shown in the console. When `false` or omitted only startup and
   successful detection messages are shown. Resolves [issue 143](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
+- Add a `payload` property to MQTT handler message configuration, along with support for
+  mustache templates in the payload. This makes it possible to send a precicely formatted
+  message to BlueIris that will trigger recording for a specific camera instead of having
+  to use webRequest handlers. Resolves [issue 151](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/151).
 - The MQTT overall configuration now supports specifing a topic for status messages.
-  Right now the only status message sent is an LWT message for when the system goes
+  Right now the only status message sent is a LWT message for when the system goes
   offline. Resolves [issue 145](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/145).
 
 ## Version 1.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,6 +1281,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-wH6Tu9mbiOt0n5EvdoWy0VGQaJMHfLIxY/6wS0xLC7CV1taM6gESEzcYy0ZlWvxxiiljYvfDIvz4hHbUUDRlhw==",
+      "dev": true
+    },
     "@types/node": {
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
@@ -7431,6 +7437,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "mustache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+      "integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "glob": "^7.1.6",
     "jsonc-parser": "^2.2.1",
     "moment": "^2.26.0",
+    "mustache": "^4.0.1",
     "node-telegram-bot-api": "^0.50.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.8",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@types/ajv-keywords": "^3.4.0",
     "@types/jest": "^25.2.3",
+    "@types/mustache": "^4.0.1",
     "@types/node": "^13.1.2",
     "@types/node-telegram-bot-api": "^0.40.3",
     "@types/request": "^2.48.5",

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -17,10 +17,6 @@ services:
       # Docker. Don't change this unless there is a need to talk to an
       # external DeepStack server somewhere and you know what you are doing.
       - DEEPSTACK_URI=http://deepstack-ai:5000/
-      # Comment this line out to disable verbose logging. Once the system is
-      # running well the extra logging information really isn't necessary
-      # and is nice to turn off.
-      - VERBOSE=true
 
     secrets:
       - triggers

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -33,11 +33,10 @@
       },
       "handlers": {
         "webRequest": {
-          "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}"]
+          "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog"]
         },
         "mqtt": {
           "topic": "aimotion/triggers/dog",
-          "payload": "{{formattedPredictions}}",
           "offDelay": 5
         },
         "telegram": {

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -33,10 +33,11 @@
       },
       "handlers": {
         "webRequest": {
-          "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog"]
+          "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}"]
         },
         "mqtt": {
           "topic": "aimotion/triggers/dog",
+          "payload": "{{formattedPredictions}}",
           "offDelay": 5
         },
         "telegram": {

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -37,7 +37,8 @@
         },
         "mqtt": {
           "topic": "aimotion/triggers/dog",
-          "offDelay": 5
+          "payload": "hi",
+          "offDelay": 0
         },
         "telegram": {
           "chatIds": [1],

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -37,8 +37,8 @@
         },
         "mqtt": {
           "topic": "aimotion/triggers/dog",
-          "payload": "hi",
-          "offDelay": 0
+          "payload": "{\"predictions\": {{predictions}}, \"camera\": \"{{name}}\", \"baseName\": \"{{baseName}}\", \"fileName\": \"{{fileName}}\", \"state\": \"{{state}}\"}",
+          "offDelay": 6
         },
         "telegram": {
           "chatIds": [1],

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -36,9 +36,9 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog"]
         },
         "mqtt": {
-          "topic": "aimotion/triggers/dog",
-          "payload": "{\"predictions\": {{predictions}}, \"camera\": \"{{name}}\", \"baseName\": \"{{baseName}}\", \"fileName\": \"{{fileName}}\", \"state\": \"{{state}}\"}",
-          "offDelay": 6
+          "topic": "BlueIris/admin",
+          "payload": "camera={{name}}&trigger",
+          "offDelay": 0
         },
         "telegram": {
           "chatIds": [1],

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -36,9 +36,8 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog"]
         },
         "mqtt": {
-          "topic": "BlueIris/admin",
-          "payload": "camera={{name}}&trigger",
-          "offDelay": 0
+          "topic": "aimotion/triggers/dog",
+          "offDelay": 5
         },
         "telegram": {
           "chatIds": [1],

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -36,9 +36,7 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}"]
         },
         "mqtt": {
-          "topic": "aimotion/triggers/dog",
-          "payload": "{{formattedPredictions}}",
-          "offDelay": 5
+          "topic": "aimotion/triggers/dog"
         },
         "telegram": {
           "chatIds": [1],

--- a/src/Log.ts
+++ b/src/Log.ts
@@ -10,8 +10,6 @@
 import chalk from "chalk";
 import moment from "moment";
 
-const isVerbose = process.env.VERBOSE ?? false;
-
 /**
  * Formats a message for output to the logs.
  * @param source The source of the message
@@ -27,19 +25,6 @@ function formatMessage(source: string, message: string) {
  * @param message The message
  */
 export function info(source: string, message: string): void {
-  console.log(formatMessage(source, message));
-}
-
-/**
- * Logs a verbose message to the console. Logs nothing if VERBOSE isn't set.
- * @param source The source of the message
- * @param message The message
- */
-export function verbose(source: string, message: string): void {
-  if (!isVerbose) {
-    return;
-  }
-
   console.log(formatMessage(source, message));
 }
 

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -29,5 +29,5 @@ export function format(
     return text;
   };
 
-  return Mustache.render(trigger.mqttConfig.payload, view);
+  return Mustache.render(template, view);
 }

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import Mustache from "mustache";
+import Trigger from "./Trigger";
+import IDeepStackPrediction from "./types/IDeepStackPrediction";
+import path from "path";
+
+export function format(
+  template: string,
+  fileName: string,
+  trigger: Trigger,
+  predictions: IDeepStackPrediction[],
+): string {
+  // Populate the payload wih the mustache template
+  const view = {
+    fileName,
+    baseName: path.basename(fileName),
+    predictions: JSON.stringify(predictions),
+    state: "on",
+    name: trigger.name,
+  };
+
+  // Turn off escaping
+  Mustache.escape = text => {
+    return text;
+  };
+
+  return Mustache.render(template, view);
+}

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -9,21 +9,6 @@ import path from 'path';
 import Trigger from './Trigger';
 import IDeepStackPrediction from './types/IDeepStackPrediction';
 
-function formatPredictions(predictions: IDeepStackPrediction[]): string {
-  return predictions
-    .map(prediction => {
-      return `${prediction.label} (${(prediction.confidence * 100).toFixed(0)}%)`;
-    })
-    .join(", ");
-}
-
-/**
- * Replaces mustache templates in a string with values
- * @param template The template string to format
- * @param fileName The filename of the image being analyzed
- * @param trigger The trigger that was fired
- * @param predictions The predictions returned by the AI system
- */
 export function format(
   template: string,
   fileName: string,
@@ -35,7 +20,6 @@ export function format(
     fileName,
     baseName: path.basename(fileName),
     predictions: JSON.stringify(predictions),
-    formattedPredictions: formatPredictions(predictions),
     state: "on",
     name: trigger.name,
   };
@@ -45,5 +29,5 @@ export function format(
     return text;
   };
 
-  return Mustache.render(template, view);
+  return Mustache.render(trigger.mqttConfig.payload, view);
 }

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -9,6 +9,21 @@ import path from 'path';
 import Trigger from './Trigger';
 import IDeepStackPrediction from './types/IDeepStackPrediction';
 
+function formatPredictions(predictions: IDeepStackPrediction[]): string {
+  return predictions
+    .map(prediction => {
+      return `${prediction.label} (${(prediction.confidence * 100).toFixed(0)}%)`;
+    })
+    .join(", ");
+}
+
+/**
+ * Replaces mustache templates in a string with values
+ * @param template The template string to format
+ * @param fileName The filename of the image being analyzed
+ * @param trigger The trigger that was fired
+ * @param predictions The predictions returned by the AI system
+ */
 export function format(
   template: string,
   fileName: string,
@@ -20,6 +35,7 @@ export function format(
     fileName,
     baseName: path.basename(fileName),
     predictions: JSON.stringify(predictions),
+    formattedPredictions: formatPredictions(predictions),
     state: "on",
     name: trigger.name,
   };

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -3,10 +3,11 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import Mustache from "mustache";
-import Trigger from "./Trigger";
-import IDeepStackPrediction from "./types/IDeepStackPrediction";
-import path from "path";
+import Mustache from 'mustache';
+import path from 'path';
+
+import Trigger from './Trigger';
+import IDeepStackPrediction from './types/IDeepStackPrediction';
 
 export function format(
   template: string,

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -57,7 +57,7 @@ export default class Trigger {
   }
 
   private async analyzeImage(fileName: string): Promise<IDeepStackPrediction[] | undefined> {
-    log.verbose(`Trigger ${this.name}`, `${fileName}: Analyzing`);
+    log.info(`Trigger ${this.name}`, `${fileName}: Analyzing`);
     const analysis = await analyzeImage(fileName);
 
     if (!analysis?.success) {
@@ -66,11 +66,11 @@ export default class Trigger {
     }
 
     if (analysis.predictions.length == 0) {
-      log.verbose(`Trigger ${this.name}`, `${fileName}: No objects detected`);
+      log.info(`Trigger ${this.name}`, `${fileName}: No objects detected`);
       return undefined;
     }
 
-    log.verbose(`Trigger ${this.name}`, `${fileName}: Found at least one object in the photo`);
+    log.info(`Trigger ${this.name}`, `${fileName}: Found at least one object in the photo`);
     return analysis.predictions;
   }
 
@@ -131,7 +131,7 @@ export default class Trigger {
     this.receivedDate = new Date(stats.atimeMs);
 
     if (this.receivedDate < this._initalizedTime && !this._processExisting) {
-      log.verbose(`Trigger ${this.name}`, `${fileName}: Skipping as it was created before the service started.`);
+      log.info(`Trigger ${this.name}`, `${fileName}: Skipping as it was created before the service started.`);
       return false;
     }
 
@@ -145,7 +145,7 @@ export default class Trigger {
     // This eases testing since this code only gets to this point for images
     // that arrived prior to startup when _processExisting is true.
     if (secondsSinceLastTrigger < this.cooldownTime && this.receivedDate > this._initalizedTime) {
-      log.verbose(
+      log.info(
         `Trigger ${this.name}`,
         `${fileName}: Skipping as it was received before the cooldown period of ${this.cooldownTime} seconds expired.`,
       );
@@ -171,7 +171,7 @@ export default class Trigger {
       !this.isMasked(fileName, prediction);
 
     if (!isTriggered) {
-      log.verbose(`Trigger ${this.name}`, `${fileName}: Not triggered by ${label} (${scaledConfidence})`);
+      log.info(`Trigger ${this.name}`, `${fileName}: Not triggered by ${label} (${scaledConfidence})`);
     } else {
       log.info(`Trigger ${this.name}`, `${fileName}: Triggered by ${label} (${scaledConfidence})`);
     }
@@ -195,7 +195,7 @@ export default class Trigger {
       const doesOverlap = mask.overlaps(predictionRect);
 
       if (doesOverlap) {
-        log.verbose(`Trigger ${this.name}`, `Prediction region ${predictionRect} blocked by trigger mask ${mask}.`);
+        log.info(`Trigger ${this.name}`, `Prediction region ${predictionRect} blocked by trigger mask ${mask}.`);
       }
 
       return doesOverlap;
@@ -215,12 +215,12 @@ export default class Trigger {
     });
 
     if (!isRegistered) {
-      log.verbose(
+      log.info(
         `Trigger ${this.name}`,
         `${fileName}: Detected object ${label} is not in the watch objects list [${this.watchObjects?.join(", ")}]`,
       );
     } else {
-      log.verbose(`Trigger ${this.name}`, `${fileName}: Matched triggering object ${label}`);
+      log.info(`Trigger ${this.name}`, `${fileName}: Matched triggering object ${label}`);
     }
 
     return isRegistered ?? false;
@@ -237,12 +237,12 @@ export default class Trigger {
     const meetsThreshold = confidence >= this.threshold.minimum && confidence <= this.threshold.maximum;
 
     if (!meetsThreshold) {
-      log.verbose(
+      log.info(
         `Trigger ${this.name}`,
         `${fileName}: Confidence ${confidence} wasn't between threshold ${this.threshold.minimum} and ${this.threshold.maximum}`,
       );
     } else {
-      log.verbose(
+      log.info(
         `Trigger ${this.name}`,
         `${fileName}: Confidence ${confidence} meets threshold ${this.threshold.minimum} and ${this.threshold.maximum}`,
       );
@@ -261,7 +261,7 @@ export default class Trigger {
 
     try {
       this._watcher = chokidar.watch(this.watchPattern).on("add", this.processImage.bind(this));
-      log.verbose(`Trigger ${this.name}`, `Listening for new images in ${this.watchPattern}`);
+      log.info(`Trigger ${this.name}`, `Listening for new images in ${this.watchPattern}`);
     } catch (e) {
       log.error(`Trigger ${this.name}`, `Unable to start watching for images: ${e}`);
       throw e;
@@ -279,6 +279,6 @@ export default class Trigger {
       throw e;
     });
 
-    log.verbose(`Trigger ${this.name}`, `Stopped listening for new images in ${this.watchPattern}`);
+    log.info(`Trigger ${this.name}`, `Stopped listening for new images in ${this.watchPattern}`);
   }
 }

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -99,10 +99,10 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[Trigger Manager] Invalid configuration file.");
   }
 
-  log.verbose("Trigger manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.info("Trigger manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   _triggers = triggerConfigJson.triggers.map(triggerJson => {
-    log.verbose("Trigger manager", `Loaded configuration for ${triggerJson.name}`);
+    log.info("Trigger manager", `Loaded configuration for ${triggerJson.name}`);
     const configuredTrigger = new Trigger({
       cooldownTime: triggerJson.cooldownTime,
       enabled: triggerJson.enabled ?? true, // If it isn't specified then enable the camera

--- a/src/handlers/mqttManager/IMqttConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttConfigJson.ts
@@ -4,5 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 export default interface IMqttConfigJson {
   topic: string;
-  offDelay: number;
+  offDelay?: number;
+  payload?: string;
 }

--- a/src/handlers/mqttManager/MqttConfig.ts
+++ b/src/handlers/mqttManager/MqttConfig.ts
@@ -7,6 +7,7 @@ export default class MqttConfig {
   public enabled: boolean;
   public offDelay: number;
   public statusTopic?: string;
+  public payload?: string;
 
   constructor(init?: Partial<MqttConfig>) {
     Object.assign(this, init);

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -65,7 +65,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[MQTT Manager] Invalid configuration file.");
   }
 
-  log.verbose("MQTT manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.info("MQTT manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   if (mqttConfigJson.statusTopic) {
     statusTopic = mqttConfigJson.statusTopic;
@@ -106,7 +106,7 @@ export async function processTrigger(
     return [];
   }
 
-  log.verbose("MQTT Manager", `${fileName}: Publishing event to ${trigger.mqttConfig.topic}`);
+  log.info("MQTT Manager", `${fileName}: Publishing event to ${trigger.mqttConfig.topic}`);
 
   // If an off delay is configured set up a timer to send the off message in the requested number of seconds
   if (trigger?.mqttConfig?.offDelay) {

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -70,6 +70,10 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     statusTopic = mqttConfigJson.statusTopic;
   }
 
+  if (mqttConfigJson.statusTopic) {
+    statusTopic = mqttConfigJson.statusTopic;
+  }
+
   mqttClient = await MQTT.connectAsync(mqttConfigJson.uri, {
     username: mqttConfigJson.username,
     password: mqttConfigJson.password,

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -71,10 +71,6 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     statusTopic = mqttConfigJson.statusTopic;
   }
 
-  if (mqttConfigJson.statusTopic) {
-    statusTopic = mqttConfigJson.statusTopic;
-  }
-
   mqttClient = await MQTT.connectAsync(mqttConfigJson.uri, {
     username: mqttConfigJson.username,
     password: mqttConfigJson.password,

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -3,17 +3,18 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import MQTT, { IPublishPacket } from "async-mqtt";
-import * as fs from "fs";
-import * as JSONC from "jsonc-parser";
-import path from "path";
-import * as mustacheFormatter from "../../MustacheFormatter";
-import * as log from "../../Log";
-import mqttManagerConfigurationSchema from "../../schemas/mqttManagerConfiguration.schema.json";
-import validateJsonAgainstSchema from "../../schemaValidator";
-import Trigger from "../../Trigger";
-import IDeepStackPrediction from "../../types/IDeepStackPrediction";
-import IMqttManagerConfigJson from "./IMqttManagerConfigJson";
+import MQTT, { IPublishPacket } from 'async-mqtt';
+import * as fs from 'fs';
+import * as JSONC from 'jsonc-parser';
+import path from 'path';
+
+import * as log from '../../Log';
+import * as mustacheFormatter from '../../MustacheFormatter';
+import mqttManagerConfigurationSchema from '../../schemas/mqttManagerConfiguration.schema.json';
+import validateJsonAgainstSchema from '../../schemaValidator';
+import Trigger from '../../Trigger';
+import IDeepStackPrediction from '../../types/IDeepStackPrediction';
+import IMqttManagerConfigJson from './IMqttManagerConfigJson';
 
 let isEnabled = false;
 let statusTopic = "node-deepstackai-trigger/status";

--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -44,7 +44,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
   if (!foundLoadableFile) {
     log.warn(
       "Telegram Manager",
-      "Unable to find a Telegram configuration file. If Telegram was disabled in the Docker configuration " +
+      "Unable to find an Telegram configuration file. If Telegram was disabled in the Docker configuration " +
         "then this warning can be safely ignored. Otherwise it means something is wrong with how the " +
         "container is configured. Verify the telegram secret points to a file called telegram.json or " +
         "that the /config mount point contains a file called telegram.json.",
@@ -62,7 +62,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     throw new Error("[Telegram Manager] Invalid configuration file.");
   }
 
-  log.verbose("Telegram manager", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.info("Telegram manager", `Loaded configuration from ${loadedConfigFilePath}`);
 
   telegramBot = new TelegramBot(telegramConfigJson.botToken, {
     filepath: false,
@@ -104,7 +104,7 @@ async function sendTelegramMessage(
   fileName: string,
   chatId: number,
 ): Promise<TelegramBot.Message> {
-  log.verbose("Telegram manager", `Sending message to ${chatId}`);
+  log.info("Telegram manager", `Sending message to ${chatId}`);
 
   const message = telegramBot
     .sendPhoto(chatId, await fsPromise.readFile(fileName), {
@@ -137,7 +137,7 @@ function passesCooldownTime(fileName: string, trigger: Trigger): boolean {
   const secondsSinceLastTrigger = (trigger.receivedDate.getTime() - lastTriggerTime.getTime()) / 1000;
 
   if (secondsSinceLastTrigger < trigger.telegramConfig.cooldownTime) {
-    log.verbose(
+    log.info(
       `Telegram manager`,
       `${fileName}: Skipping sending message as the cooldown period of ${trigger.telegramConfig.cooldownTime} seconds hasn't expired.`,
     );
@@ -153,7 +153,7 @@ function passesCooldownTime(fileName: string, trigger: Trigger): boolean {
  */
 function readRawConfigFile(configFilePath: string): string {
   if (!configFilePath) {
-    log.verbose(
+    log.info(
       "Telegram Manager",
       `No configuration file was specified so Telegram events won't be sent. To enable Telegram events make sure the telegram secret in the docker-compose.yaml points to a configuration file.`,
     );

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -7,6 +7,7 @@ import request from "request-promise-native";
 import * as log from "../../Log";
 import Trigger from "../../Trigger";
 import IDeepStackPrediction from "../../types/IDeepStackPrediction";
+import * as mustacheFormatter from "../../MustacheFormatter";
 
 /**
  * Handles calling a list of web URLs.
@@ -23,7 +24,12 @@ export async function processTrigger(
     return [];
   }
 
-  return Promise.all(trigger.webRequestHandlerConfig.triggerUris?.map(uri => callTriggerUri(fileName, trigger, uri)));
+  return Promise.all(
+    trigger.webRequestHandlerConfig.triggerUris?.map(uri => {
+      const formattedUri = encodeURI(mustacheFormatter.format(uri, fileName, trigger, predictions));
+      callTriggerUri(fileName, trigger, formattedUri);
+    }),
+  );
 }
 
 /**

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -7,7 +7,6 @@ import request from "request-promise-native";
 import * as log from "../../Log";
 import Trigger from "../../Trigger";
 import IDeepStackPrediction from "../../types/IDeepStackPrediction";
-import * as mustacheFormatter from "../../MustacheFormatter";
 
 /**
  * Handles calling a list of web URLs.
@@ -24,12 +23,7 @@ export async function processTrigger(
     return [];
   }
 
-  return Promise.all(
-    trigger.webRequestHandlerConfig.triggerUris?.map(uri => {
-      const formattedUri = encodeURI(mustacheFormatter.format(uri, fileName, trigger, predictions));
-      callTriggerUri(fileName, trigger, formattedUri);
-    }),
-  );
+  return Promise.all(trigger.webRequestHandlerConfig.triggerUris?.map(uri => callTriggerUri(fileName, trigger, uri)));
 }
 
 /**

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -31,7 +31,7 @@ export async function processTrigger(
  * @param uri The uri to trigger
  */
 async function callTriggerUri(fileName: string, trigger: Trigger, uri: string): Promise<void> {
-  log.verbose("Web request", `${fileName}: Calling trigger uri ${uri}`);
+  log.info("Web request", `${fileName}: Calling trigger uri ${uri}`);
   try {
     await request.get(uri);
   } catch (e) {

--- a/src/schemas/mqttHandlerConfiguration.schema.json
+++ b/src/schemas/mqttHandlerConfiguration.schema.json
@@ -18,6 +18,11 @@
       "default": 30,
       "examples": ["0", "300"]
     },
+    "payload": {
+      "description": "The payload to send with the MQTT message. Optional. If omitted a payload containing the prediction information and image file path will be sent.",
+      "type": "string",
+      "examples": ["{\"camera\": \"FrontDoor\", \"state\": \"on\"}"]
+    },
     "enabled": {
       "description": "Enables the MQTT handler on this trigger. Default is true.",
       "type": "boolean",


### PR DESCRIPTION
# Fixes #148

## Description of changes

- Adds mustache template support to webRequest URIs
- Adds `formattedPredictions` as a variable

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
