### PR TITLE
Add support for multiple MQTT topics on a single trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- MQTT trigger handlers now support an array of messages to send instead of a single message, allowing
+  for different format messages to different services. For example one message could be formatted
+  in a way that works for Home Assistant use and another could be formatted to trigger BlueIris recording.
+  **This is a breaking change to the trigger.conf file format**. If you have existing MQTT triggers
+  configured they will need to be updated with this release by wrapping your existing
+  trigger in `[]` to turn it into an array. See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers#defining-mqtt-handlers)
+  for an example of the new format. Resolves [issue 153](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/153).
 - A `payload` property is now supported on MQTT handler message configuration, along with support for
   mustache templates in the payload. This makes it possible to send a precicely formatted
   message to BlueIris that will trigger recording for a specific camera instead of having

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
   for different format messages to different services. For example one message could be formatted
   in a way that works for Home Assistant use and another could be formatted to trigger BlueIris recording.
   **This is a breaking change to the trigger.conf file format**. If you have existing MQTT triggers
-  configured they will need to be updated with this release by wrapping your existing
-  trigger in `[]` to turn it into an array. See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers#defining-mqtt-handlers)
+  configured they will need to be updated with this release. See [the wiki](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers#defining-mqtt-handlers)
   for an example of the new format. Resolves [issue 153](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/153).
 - A `payload` property is now supported on MQTT handler message configuration, along with support for
   mustache templates in the payload. This makes it possible to send a precicely formatted

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -14,7 +14,7 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Cat"]
         },
         "mqtt": {
-          "topic": "aimotion/triggers/cat"
+          "messages": [{ "topic": "aimotion/triggers/cat" }]
         },
         "telegram": {
           "chatIds": [1],
@@ -36,7 +36,7 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}"]
         },
         "mqtt": {
-          "topic": "aimotion/triggers/dog"
+          "messages": [{ "topic": "aimotion/triggers/dog" }]
         },
         "telegram": {
           "chatIds": [1],

--- a/sampleConfiguration/triggers.json
+++ b/sampleConfiguration/triggers.json
@@ -36,7 +36,11 @@
           "triggerUris": ["http://localhost:81/admin?trigger&camera=Dog&memo={{formattedPredictions}}"]
         },
         "mqtt": {
-          "messages": [{ "topic": "aimotion/triggers/dog" }]
+          "messages": [
+            { "topic": "aimotion/triggers/dog", "offDelay": 5 },
+            { "topic": "aimotion/triggers/dog2" },
+            { "topic": "aimotion/triggers/dog3" }
+          ]
         },
         "telegram": {
           "chatIds": [1],

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -10,7 +10,7 @@ import * as TelegramManager from "./handlers/telegramManager/TelegramManager";
 import * as WebRequestHandler from "./handlers/webRequest/WebRequestHandler";
 import analyzeImage from "./DeepStack";
 import IDeepStackPrediction from "./types/IDeepStackPrediction";
-import MqttConfig from "./handlers/mqttManager/MqttConfig";
+import MqttHandlerConfig from "./handlers/mqttManager/MqttHandlerConfig";
 import TelegramConfig from "./handlers/telegramManager/TelegramConfig";
 import WebRequestConfig from "./handlers/webRequest/WebRequestConfig";
 import { Stats } from "fs";
@@ -38,7 +38,7 @@ export default class Trigger {
 
   // Handler configurations
   public webRequestHandlerConfig: WebRequestConfig;
-  public mqttConfig: MqttConfig;
+  public mqttConfig: MqttHandlerConfig;
   public telegramConfig: TelegramConfig;
 
   constructor(init?: Partial<Trigger>) {

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -5,7 +5,7 @@
 import * as JSONC from "jsonc-parser";
 import * as log from "./Log";
 import ITriggerConfigJson from "./types/ITriggerConfigJson";
-import MqttConfig from "./handlers/mqttManager/MqttConfig";
+import MqttHandlerConfig from "./handlers/mqttManager/MqttHandlerConfig";
 import TelegramConfig from "./handlers/telegramManager/TelegramConfig";
 import Trigger from "./Trigger";
 import triggerSchema from "./schemas/triggerConfiguration.schema.json";
@@ -125,7 +125,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
       configuredTrigger.webRequestHandlerConfig = new WebRequestConfig(triggerJson.handlers.webRequest);
     }
     if (triggerJson.handlers.mqtt) {
-      configuredTrigger.mqttConfig = new MqttConfig(triggerJson.handlers.mqtt);
+      configuredTrigger.mqttConfig = new MqttHandlerConfig(triggerJson.handlers.mqtt);
     }
     if (triggerJson.handlers.telegram) {
       configuredTrigger.telegramConfig = new TelegramConfig(triggerJson.handlers.telegram);

--- a/src/handlers/mqttManager/IMqttHandlerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttHandlerConfigJson.ts
@@ -2,8 +2,9 @@
  *  Copyright (c) Neil Enns. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-export default interface IMqttConfigJson {
-  topic: string;
-  offDelay?: number;
-  payload?: string;
+import IMqttMessageConfigJson from "./IMqttMessageConfigJson";
+
+export default interface IMqttHandlerConfigJson {
+  messages: IMqttMessageConfigJson[];
+  enabled?: boolean;
 }

--- a/src/handlers/mqttManager/IMqttMessageConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttMessageConfigJson.ts
@@ -2,15 +2,8 @@
  *  Copyright (c) Neil Enns. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-export default class MqttMessageConfig {
-  public topic: string;
-  public offDelay?: number;
-  public payload?: string;
-
-  constructor(init?: Partial<MqttMessageConfig>) {
-    Object.assign(this, init);
-
-    // Default offDelay is 30 seconds if not specified
-    this.offDelay = init?.offDelay ?? 30;
-  }
+export default interface IMqttMessageConfigJson {
+  topic: string;
+  payload?: string;
+  offDelay?: number;
 }

--- a/src/handlers/mqttManager/MqttHandlerConfig.ts
+++ b/src/handlers/mqttManager/MqttHandlerConfig.ts
@@ -7,7 +7,6 @@ import MqttMessageConfig from "./MqttMessageConfig";
 export default class MqttHandlerConfig {
   public messages: MqttMessageConfig[];
   public enabled: boolean;
-  public offDelay: number;
   public statusTopic?: string;
 
   constructor(init?: Partial<MqttHandlerConfig>) {

--- a/src/handlers/mqttManager/MqttHandlerConfig.ts
+++ b/src/handlers/mqttManager/MqttHandlerConfig.ts
@@ -2,20 +2,25 @@
  *  Copyright (c) Neil Enns. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-export default class MqttConfig {
-  public topic: string;
+import MqttMessageConfig from "./MqttMessageConfig";
+
+export default class MqttHandlerConfig {
+  public messages: MqttMessageConfig[];
   public enabled: boolean;
   public offDelay: number;
   public statusTopic?: string;
-  public payload?: string;
 
-  constructor(init?: Partial<MqttConfig>) {
+  constructor(init?: Partial<MqttHandlerConfig>) {
     Object.assign(this, init);
+
+    // Create the messages. Done this way to get real objects
+    // with a constuctor that sets default values, instead of
+    // rawproperty assignment done by Object.assign().
+    this.messages = init?.messages.map(rawMessage => {
+      return new MqttMessageConfig(rawMessage);
+    });
 
     // Default for enabled is true if it isn't specified in the config file
     this.enabled = init?.enabled ?? true;
-
-    // Default offDelay is 30 seconds if not specified
-    this.offDelay = init?.offDelay ?? 30;
   }
 }

--- a/src/handlers/mqttManager/MqttMessageConfig.ts
+++ b/src/handlers/mqttManager/MqttMessageConfig.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export default class MqttMessageConfig {
+  public offDelay: number;
+  public topic: string;
+  public payload?: string;
+
+  constructor(init?: Partial<MqttMessageConfig>) {
+    Object.assign(this, init);
+
+    // Default offDelay is 30 seconds if not specified
+    this.offDelay = init?.offDelay ?? 30;
+  }
+}

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -27,7 +27,7 @@ export async function processTrigger(
   return Promise.all(
     trigger.webRequestHandlerConfig.triggerUris?.map(uri => {
       const formattedUri = encodeURI(mustacheFormatter.format(uri, fileName, trigger, predictions));
-      callTriggerUri(fileName, trigger, formattedUri);
+      return callTriggerUri(fileName, trigger, formattedUri);
     }),
   );
 }

--- a/src/schemas/mqttHandlerConfiguration.schema.json
+++ b/src/schemas/mqttHandlerConfiguration.schema.json
@@ -4,30 +4,41 @@
   "type": "object",
   "title": "The configuration for an MQTT trigger handler",
   "description": "Defines the MQTT information sent with trigger notifications.",
-  "required": ["topic"],
+  "required": ["messages"],
   "properties": {
-    "topic": {
-      "description": "The topic to send when this handler is triggered.",
-      "type": "string",
-      "minLength": 1,
-      "examples": ["aimotion/trigger/dog"]
-    },
-    "offDelay": {
-      "description": "Number of seconds of no motion to wait before sending an MQTT state off message. Set to 0 to disable sending off messages. Default is 30 seconds.",
-      "type": "number",
-      "default": 30,
-      "examples": ["0", "300"]
-    },
-    "payload": {
-      "description": "The payload to send with the MQTT message. Optional. If omitted a payload containing the prediction information and image file path will be sent.",
-      "type": "string",
-      "examples": ["{\"camera\": \"FrontDoor\", \"state\": \"on\"}"]
-    },
-    "enabled": {
-      "description": "Enables the MQTT handler on this trigger. Default is true.",
-      "type": "boolean",
-      "default": "true",
-      "examples": ["false"]
+    "messages": {
+      "description": "A list of MQTT messages to send when the trigger is activated.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["topic"],
+        "properties": {
+          "topic": {
+            "description": "The topic to send when this handler is triggered.",
+            "type": "string",
+            "minLength": 1,
+            "examples": ["aimotion/trigger/dog"]
+          },
+          "offDelay": {
+            "description": "Number of seconds of no motion to wait before sending an MQTT state off message. Set to 0 to disable sending off messages. Default is 30 seconds.",
+            "type": "number",
+            "default": 30,
+            "examples": ["0", "300"]
+          },
+          "payload": {
+            "description": "The payload to send with the MQTT message. Optional. If omitted a payload containing the prediction information and image file path will be sent.",
+            "type": "string",
+            "examples": ["{\"camera\": \"FrontDoor\", \"state\": \"on\"}"]
+          }
+        }
+      },
+      "enabled": {
+        "description": "Enables the MQTT handler on this trigger. Default is true.",
+        "type": "boolean",
+        "default": "true",
+        "examples": ["false"]
+      }
     }
   }
 }

--- a/src/types/ITriggerJson.ts
+++ b/src/types/ITriggerJson.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Neil Enns. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import IMqttConfigJson from "../handlers/mqttManager/IMqttConfigJson";
+import IMqttHandlerConfigJson from "../handlers/mqttManager/IMqttHandlerConfigJson";
 import ITelegramConfigJson from "../handlers/telegramManager/ITelegramConfigJson";
 import IWebRequestHandlerJson from "../handlers/webRequest/IWebRequestHandlerJson";
 import Rect from "../Rect";
@@ -21,7 +21,7 @@ export default interface ITriggerJson {
   // Handler settings
   handlers: {
     webRequest: IWebRequestHandlerJson;
-    mqtt: IMqttConfigJson;
+    mqtt: IMqttHandlerConfigJson;
     telegram: ITelegramConfigJson;
   };
 


### PR DESCRIPTION
# Fixes #153

## Description of changes

Turned the mqtt handler into an array with message objects inside of it.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
