### PR TITLE
Don't exit on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- The system no longer exits when configuration errors prevent startup. This leaves the container in
+  a running state so it is possible to open a terminal window to the container to inspect
+  things like volume mount points for missing configuration files. Resolves [issue 164](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/154).
 - Telegram trigger handlers now support an optional `caption` property to specify the text sent
   as the caption for the photo that fired the trigger. This supports mustache templates so the
   caption can be something like `{{name}}: {{formattedPredictions}}`. Resolves [issue 154](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/154).

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,12 +46,12 @@ async function main() {
 
     // Start watching
     TriggerManager.startWatching();
-
-    wait();
   } catch (e) {
     log.error("Main", e.message);
-    process.exit(1);
+    // process.exit(1);
   }
+
+  wait();
 }
 
 function wait() {


### PR DESCRIPTION
Fixes #164

## Description of changes

- Always go into the wait loop instead of exiting on errors.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
