### PR TITLE
Send processing statistics via MQTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- MQTT status messages with statistics are now sent on every received file. The total
+  number of files received and the number of triggers actually fired are included in
+  the message payload. Resolves [issue 146](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/146).
 - Fix typos in the source code. Resolves [issue 170](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/170).
 - Add a clear message after initialization indicating whether startup was successful.
   If it wasn't there's now a link to a troubleshooting wiki page for assistance. Resolves

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -14,6 +14,18 @@ import WebRequestConfig from "./handlers/webRequest/WebRequestConfig";
 import * as fs from "fs";
 import Rect from "./Rect";
 
+/**
+ * Provides a running total of the number of times an image caused triggers
+ * to fire. Use the incrementTriggeredCount() method to update the total.
+ */
+export let triggeredCount = 0;
+
+/**
+ * Provides a running total of the number of files analyzed.
+ * Use the incrementAnalyzedFiles() method to update the total.
+ */
+export let analyzedFilesCount = 0;
+
 let _triggers: Trigger[];
 
 /**
@@ -147,4 +159,18 @@ export function startWatching(): void {
  */
 export async function stopWatching(): Promise<void[]> {
   return Promise.all(_triggers.map(trigger => trigger.stopWatching()));
+}
+
+/**
+ * Adds one to the triggered count total.
+ */
+export function incrementTriggeredCount(): void {
+  triggeredCount += 1;
+}
+
+/**
+ * Adds one to the false positive count total.
+ */
+export function incrementAnalyzedFilesCount(): void {
+  analyzedFilesCount += 1;
 }


### PR DESCRIPTION
Fixes #146

## Description of changes

Add a new message that gets sent after every trigger processes a received file. Includes number of successful triggers and total number of files.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
