### PR TITLE
Fix double-encoding of URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- webRequest URIs are no longer double-encoded. Instead only the text replaced with a
+  mustache template is encoded. **This is a breaking change**. If you previously
+  worked around the bug by removing encoding from the URIs in the trigger configuration
+  file you will need to put the encoding in again. Resolves [issue 176](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/176).
 - Failed calls to the Deepstack server no longer throw an unhandled promise rejection
   exception. Resolves [issue 175](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/175).
 

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -3,11 +3,11 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import Mustache from 'mustache';
-import path from 'path';
+import Mustache from "mustache";
+import path from "path";
 
-import Trigger from './Trigger';
-import IDeepStackPrediction from './types/IDeepStackPrediction';
+import Trigger from "./Trigger";
+import IDeepStackPrediction from "./types/IDeepStackPrediction";
 
 function formatPredictions(predictions: IDeepStackPrediction[]): string {
   return predictions
@@ -17,6 +17,9 @@ function formatPredictions(predictions: IDeepStackPrediction[]): string {
     .join(", ");
 }
 
+function optionallyEncode(value: string, urlEncode: boolean): string {
+  return urlEncode ? encodeURIComponent(value) : value;
+}
 /**
  * Replaces mustache templates in a string with values
  * @param template The template string to format
@@ -29,13 +32,14 @@ export function format(
   fileName: string,
   trigger: Trigger,
   predictions: IDeepStackPrediction[],
+  urlEncode = false,
 ): string {
   // Populate the payload wih the mustache template
   const view = {
-    fileName,
-    baseName: path.basename(fileName),
-    predictions: JSON.stringify(predictions),
-    formattedPredictions: formatPredictions(predictions),
+    fileName: optionallyEncode(fileName, urlEncode),
+    baseName: optionallyEncode(path.basename(fileName), urlEncode),
+    predictions: optionallyEncode(JSON.stringify(predictions), urlEncode),
+    formattedPredictions: optionallyEncode(formatPredictions(predictions), urlEncode),
     state: "on",
     name: trigger.name,
   };

--- a/src/handlers/webRequest/WebRequestHandler.ts
+++ b/src/handlers/webRequest/WebRequestHandler.ts
@@ -26,7 +26,7 @@ export async function processTrigger(
 
   return Promise.all(
     trigger.webRequestHandlerConfig.triggerUris?.map(uri => {
-      const formattedUri = encodeURI(mustacheFormatter.format(uri, fileName, trigger, predictions));
+      const formattedUri = mustacheFormatter.format(uri, fileName, trigger, predictions, true);
       return callTriggerUri(fileName, trigger, formattedUri);
     }),
   );


### PR DESCRIPTION
Fixes #176

## Description of changes

Stop encoding the entire webRequest URIs and only encode the mustache template replaced text. This is, sadly, a breaking change.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
