### PR TITLE
Send a state=online message on MQTT startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- MQTT `online` and `offline` status messages are now sent when the service starts or fails
+  to start. This, combined the LWT message, makes it easy to set up MQTT binary sensors in Home Assistant
+  to track the status of the system and send notifications to people if the system goes down
+  or isn' running. **This is a breaking change**. The format of the offline message sent for the LWT
+  changed to align with the online and processing status messages. [See the wiki for documentation
+  on the status message format](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Configuration#enabling--configuring-mqtt). Resolves [issue182](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/182).
 - webRequest URIs are no longer double-encoded. Instead only the text replaced with a
   mustache template is encoded. **This is a breaking change**. If you previously
   worked around the bug by removing encoding from the URIs in the trigger configuration

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -79,7 +79,7 @@ export async function loadConfiguration(configFilePaths: string[]): Promise<void
     rejectUnauthorized: mqttConfigJson.rejectUnauthorized ?? true,
     will: {
       topic: statusTopic,
-      payload: "offline",
+      payload: JSON.stringify({ state: "offline" }),
       qos: 2,
       retain: false,
     },
@@ -172,6 +172,9 @@ export async function publishStatisticsMessage(
     await mqttClient.publish(
       statusTopic,
       JSON.stringify({
+        // Ensures the status still reflects as up and running for people
+        // that have an MQTT binary sensor in Home Assistant
+        state: "online",
         triggerCount,
         analyzedFilesCount,
       }),
@@ -179,6 +182,22 @@ export async function publishStatisticsMessage(
   ];
 }
 
+/**
+ * Sends a simple message indicating the service is up and running
+ */
+export async function sendOnlineEvent(): Promise<IPublishPacket> {
+  // Don't do anything if the MQTT client wasn't configured
+  if (!mqttClient) {
+    return;
+  }
+
+  return mqttClient.publish(statusTopic, JSON.stringify({ state: "online" }));
+}
+
+/**
+ * Sends a message indicating the motion for a particular trigger has stopped
+ * @param topic The topic to publish the message on
+ */
 async function publishOffEvent(topic: string): Promise<IPublishPacket> {
   return await mqttClient.publish(topic, JSON.stringify({ state: "off" }));
 }

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -185,13 +185,13 @@ export async function publishStatisticsMessage(
 /**
  * Sends a simple message indicating the service is up and running
  */
-export async function sendOnlineEvent(): Promise<IPublishPacket> {
+export async function publishServerState(state: string, details?: string): Promise<IPublishPacket> {
   // Don't do anything if the MQTT client wasn't configured
   if (!mqttClient) {
     return;
   }
 
-  return mqttClient.publish(statusTopic, JSON.stringify({ state: "online" }));
+  return mqttClient.publish(statusTopic, JSON.stringify({ state, details }));
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,12 @@ async function main() {
 
     // Start watching
     TriggerManager.startWatching();
-    log.error("Main", "****************************************");
-    log.error("Main", "Up and running!");
+
+    // Notify it's up and running
+    await MqttManager.sendOnlineEvent();
+
+    log.info("Main", "****************************************");
+    log.info("Main", "Up and running!");
   } catch (e) {
     log.error("Main", e.message);
     log.error("Main", "****************************************");


### PR DESCRIPTION
Fixes #182

## Description of changes

- `"state": "online"` is now sent at successful startup and with every successful processed image to the status topic.
- `"state": "offline"` is now the LWT message. It just to just be `"offline"`
- `"state": "offline"` is now sent on failed startup along with `details` that shows the error message.

This is a breaking change due to the LWT message changing format.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
