### PR TITLE
Include formattedPredictions in default MQTT message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- MQTT detection messages now include a friendly formatted version of the predictions,
+  for example: `"formattedPredictions": "dog (98%)"`. Resolves [issue 181](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/181).
 - MQTT `online` and `offline` status messages are now sent when the service starts or fails
   to start. This, combined the LWT message, makes it easy to set up MQTT binary sensors in Home Assistant
   to track the status of the system and send notifications to people if the system goes down

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -9,7 +9,7 @@ import path from "path";
 import Trigger from "./Trigger";
 import IDeepStackPrediction from "./types/IDeepStackPrediction";
 
-function formatPredictions(predictions: IDeepStackPrediction[]): string {
+export function formatPredictions(predictions: IDeepStackPrediction[]): string {
   return predictions
     .map(prediction => {
       return `${prediction.label} (${(prediction.confidence * 100).toFixed(0)}%)`;

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -148,6 +148,7 @@ async function publishDetectionMessage(
         fileName,
         basename: path.basename(fileName),
         predictions,
+        formattedPredictions: mustacheFormatter.formatPredictions(predictions),
         state: "on",
       });
 


### PR DESCRIPTION
Fixes #181

## Description of changes

formattedPredictions are now included in the MQTT message.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
