### PR TITLE
Map a datastore directory in the Docker image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,12 @@ RUN mkdir -p ${NPM_GLOBAL} \
 
 # Create the vscode workspace and .git folder and set the owner to
 # the node user so git commands work
-RUN mkdir -p /workspace/.git && chown -R node:node /workspace/.git
+# Create the local storage folder and set ownership of it so once a volume
+# is mounted there the permissions are correct
+RUN mkdir -p /workspace/.git \
+    && mkdir -p /node-deepstackai-trigger \
+    && chown -R node:node /workspace/.git \
+    && chown -R node:node /node-deepstackai-trigger
 
 ENV CHOKIDAR_USEPOLLING=true
 USER node

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ..:/workspace:cached
       - ../sampleConfiguration/aiinput:/aiinput
+      - localtriggerstorage:/node-deepstackai-trigger
     secrets:
       - triggers
       - mqtt
@@ -49,6 +50,7 @@ services:
 
 volumes:
   localstorage:
+  localtriggerstorage:
 
 secrets:
   triggers:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,9 +10,14 @@
     "ajvkeywords",
     "cooldowns",
     "danecreekphotography",
+    "davidanson",
+    "dbaeumer",
     "deepquestai",
     "deepstackai",
+    "devcontainer",
+    "esbenp",
     "localstorage",
-    "mqtts"
+    "mqtts",
+    "streetsidesoftware"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- An optional `/node-deepstackai-trigger` mount point exists for future use. Resolves
+  [issue 191](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/191).
+
 ## Version 2.0.0
 
 ### Breaking changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,15 @@ COPY --chown=node:node . .
 RUN npm ci --no-optional
 RUN npm run webpack
 
-# This is the final produciton image
+# This is the final production image
 FROM node:alpine
 # Install tzdata so the timezone can be set correctly in the image via
 # the TZ environment variable.
 RUN apk --no-cache update && apk --no-cache upgrade && apk --no-cache add tzdata
+
+# Pre-create the temporary storage folder so it has the right user
+# permissions on it after volume mount
+RUN mkdir -p /node-deepstackai-trigger && chown -R node:node /node-deepstackai-trigger
 
 WORKDIR /home/node/app
 USER node

--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,6 +1281,15 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/mkdirp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
+      "integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mustache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "devDependencies": {
     "@types/ajv-keywords": "^3.4.0",
     "@types/jest": "^25.2.3",
+    "@types/mkdirp": "^1.0.1",
     "@types/mustache": "^4.0.1",
     "@types/node": "^13.1.2",
     "@types/node-telegram-bot-api": "^0.40.3",

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       # Change ./path_to_local_ai_images_folder to point to the folder that
       # will have the images to analyze
       - ./path_to_local_ai_images_folder:/aiinput
+      # Leave this unchanged, required for temporary data file storage
+      - localtriggerstorage:/node-deepstackai-trigger
 
     environment:
       # Change this to match the timezone the images are produced in,
@@ -44,6 +46,7 @@ services:
 
 volumes:
   localstorage:
+  localtriggerstorage:
 
 secrets:
   triggers:

--- a/src/WebStorageManager.ts
+++ b/src/WebStorageManager.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import mkdirp from "mkdirp";
+import * as log from "./Log";
+
+/**
+ * Local location where all web images are stored.
+ */
+const localStoragePath = "/node-deepstackai-trigger/www";
+
+/**
+ * Creates the data storage directory for the web images
+ */
+export function initializeStorage(): void {
+  log.info("Web storage", `Creating local storage folder ${localStoragePath}.`);
+  mkdirp.sync(localStoragePath);
+}


### PR DESCRIPTION
Fixes #191

## Description of changes

- Creates a www folder in /node-deepstackai-trigger for use in the future as a storage location for annotated images.
- Update the Dockerfile to generate a final image with the mount point pre-defined with the right user permissions
- Update the sample docker-compose.yaml file to include the volume mount
- Update the .devcontainer configuration to pre-define the folder and mount a volume

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
