### PR TITLE
Purge old local storage files

### DIFF
--- a/src/LocalStorageManager.ts
+++ b/src/LocalStorageManager.ts
@@ -9,6 +9,21 @@ import { promises as fsPromise } from "fs";
 import path from "path";
 
 /**
+ * How long an image has to sit in local storage before it gets removed, in seconds.
+ */
+let purgeThreshold = 60;
+
+/**
+ * How often the purge runs, in seconds.
+ */
+let purgeInterval = 30;
+
+/**
+ * The background timer that runs the local file purge.
+ */
+let backgroundTimer: NodeJS.Timeout;
+
+/**
  * Local location where all web images are stored.
  */
 export const localStoragePath = "/node-deepstackai-trigger/www";
@@ -41,4 +56,48 @@ export async function copyToLocalStorage(fileName: string): Promise<string> {
   });
 
   return localFileName;
+}
+
+/**
+ * Starts a background task that purges old files from local storage
+ * @param threshold Age of a file, in seconds, to get purged
+ * @param interval Frequency of purge, in seconds
+ */
+export function startBackgroundPurge(interval: number, threshold: number): void {
+  log.info("Local storage", `Enabling background purge every ${interval} seconds.`);
+  purgeThreshold = threshold;
+  purgeInterval = interval;
+  purgeOldFiles();
+}
+
+/**
+ * Stops the background purge process from running.
+ */
+export function stopBackgroundPurge(): void {
+  clearTimeout(backgroundTimer);
+  log.info("Local storage", `Background purge stopped.`);
+}
+
+/**
+ * Purges files older than the purgeThreshold from local storage
+ */
+async function purgeOldFiles(): Promise<void> {
+  log.info("Local storage", "Running purge");
+
+  (await fsPromise.readdir(localStoragePath)).map(async fileName => {
+    const fullLocalPath = mapToLocalStorage(fileName);
+    const lastAccessTime = (await fsPromise.stat(fullLocalPath)).atime;
+
+    const secondsSinceLastAccess = (new Date().getTime() - lastAccessTime.getTime()) / 1000;
+
+    if (secondsSinceLastAccess > purgeThreshold) {
+      await fsPromise.unlink(fullLocalPath);
+      log.info("Local storage", `Purging ${fileName}. Age: ${secondsSinceLastAccess}`);
+    }
+
+    // Get last access time
+  });
+
+  log.info("Local storage", "Purge complete");
+  backgroundTimer = setTimeout(purgeOldFiles, purgeInterval * 1000);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ async function main() {
 
     // Initialize the web storage
     await LocalStorageManager.initializeStorage();
-    LocalStorageManager.startBackgroundPurge(30, 60);
+    LocalStorageManager.startBackgroundPurge(1, 1);
 
     if (!validateEnvironmentVariables()) {
       throw Error(

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ async function main() {
 
     // Initialize the web storage
     await LocalStorageManager.initializeStorage();
+    LocalStorageManager.startBackgroundPurge(30, 60);
 
     if (!validateEnvironmentVariables()) {
       throw Error(


### PR DESCRIPTION
# Fixes #193

## Description of changes

Adds a purge that runs every _n_ minutes to purge images older than _n_ minutes. Still doesn't read from an environment variable, that'll come soon.

## Checklist

No public facing changes yet.