### PR TITLE
Properly handle missing file when sending telegram messages

### DIFF
--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -108,7 +108,14 @@ export async function processTrigger(
     : fileName;
 
   // Send all the messages
-  return Promise.all(trigger.telegramConfig.chatIds.map(chatId => sendTelegramMessage(caption, imageFileName, chatId)));
+  try {
+    return Promise.all(
+      trigger.telegramConfig.chatIds.map(chatId => sendTelegramMessage(caption, imageFileName, chatId)),
+    );
+  } catch (e) {
+    log.warn("Telegram manager", `Unable to send message: ${e.error}`);
+    return [];
+  }
 }
 
 async function sendTelegramMessage(

--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -125,12 +125,17 @@ async function sendTelegramMessage(
 ): Promise<TelegramBot.Message> {
   log.info("Telegram manager", `Sending message to ${chatId}`);
 
+  const imageBuffer = await fsPromise.readFile(fileName).catch(e => {
+    log.warn("Telegram manager", `Unable to load file: ${e.message}`);
+    return undefined;
+  });
+
   const message = telegramBot
-    .sendPhoto(chatId, await fsPromise.readFile(fileName), {
+    .sendPhoto(chatId, imageBuffer, {
       caption: triggerName,
     })
     .catch(e => {
-      log.warn("Telegram Manager", `Unable to send message: ${e.message}`);
+      log.warn("Telegram manager", `Unable to send message: ${e.message}`);
       return undefined;
     });
 


### PR DESCRIPTION
# Fixes #208 

## Description of changes

Add a `catch()` to `fs.readFile()`.

## Checklist

Not needed