### PR TITLE
Annotation boxes are too big

### DIFF
--- a/src/handlers/annotationManager/AnnotationManager.ts
+++ b/src/handlers/annotationManager/AnnotationManager.ts
@@ -29,12 +29,9 @@ export async function processTrigger(
   context.fontBaseline = "top";
 
   predictions.map(prediction => {
-    context.strokeRect(
-      prediction.x_min,
-      prediction.y_min,
-      prediction.x_max - prediction.x_min,
-      prediction.y_max - prediction.y_min,
-    );
+    const width = prediction.x_max - prediction.x_min;
+    const height = prediction.y_max - prediction.y_min;
+    context.strokeRect(prediction.x_min, prediction.y_min, width, height);
     context.fillText(
       `${prediction.label} (${(prediction.confidence * 100).toFixed(0)}%)`,
       prediction.x_min + 10,

--- a/src/handlers/annotationManager/AnnotationManager.ts
+++ b/src/handlers/annotationManager/AnnotationManager.ts
@@ -29,7 +29,12 @@ export async function processTrigger(
   context.fontBaseline = "top";
 
   predictions.map(prediction => {
-    context.strokeRect(prediction.x_min, prediction.y_min, prediction.x_max, prediction.y_max);
+    context.strokeRect(
+      prediction.x_min,
+      prediction.y_min,
+      prediction.x_max - prediction.x_min,
+      prediction.y_max - prediction.y_min,
+    );
     context.fillText(
       `${prediction.label} (${(prediction.confidence * 100).toFixed(0)}%)`,
       prediction.x_min + 10,


### PR DESCRIPTION
# Fixes #217 

## Description of changes

Use width and height instead of x_max and y_max.

## Checklist

Not needed.