### PR TITLE
Resolve buffer deprecation warning from random library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY --from=build --chown=node:node /home/node/app/fonts/CascadiaCode.ttf ./font
 # This can always be set to false in docker-compose.yml later if necessary.
 ENV CHOKIDAR_USEPOLLING=true
 
-ENTRYPOINT [ "node", "bundle.js" ]
+ENTRYPOINT [ "node", "--no-deprecation", "bundle.js" ]


### PR DESCRIPTION
# Fixes #203

## Description of changes

Add `--no-deprecation` to the node command line in the final Docker image. Feels like an ugly hack but there's no other option that I can find.

## Checklist

Not needed