### PR TITLE
Handle installs prior to annotation feature 

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     volumes:
       - ..:/workspace:cached
       - ../sampleConfiguration/aiinput:/aiinput
-      - localtriggerstorage:/node-deepstackai-trigger
     secrets:
       - triggers
       - mqtt
@@ -52,7 +51,6 @@ services:
 
 volumes:
   localstorage:
-  localtriggerstorage:
 
 secrets:
   triggers:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,10 @@
     "Ghhiijjkkllmm",
     "MQTT",
     "NTBA",
+    "aiinput",
     "aimotion",
     "ajvkeywords",
+    "bufferutil",
     "cascadia",
     "cooldowns",
     "danecreekphotography",
@@ -19,7 +21,10 @@
     "esbenp",
     "localstorage",
     "localtriggerstorage",
+    "markdownlint",
+    "mosquitto",
     "mqtts",
+    "postversion",
     "pureimage",
     "streetsidesoftware"
   ]

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       # Change ./path_to_local_ai_images_folder to point to the folder that
       # will have the images to analyze
       - ./path_to_local_ai_images_folder:/aiinput
-      # Leave this unchanged, required for temporary data file storage
-      - localtriggerstorage:/node-deepstackai-trigger
 
     environment:
       # Change this to match the timezone the images are produced in,
@@ -53,7 +51,6 @@ services:
 
 volumes:
   localstorage:
-  localtriggerstorage:
 
 secrets:
   triggers:


### PR DESCRIPTION
# Fixes #201 

## Description of changes

Remove the default mount of local storage. It isn't needed, these files are transient and don't have to live belong the container's lifetime. If necessary the volume can get mounted separately, and there's info in the wiki on how to do that.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md