### PR TITLE
Add a DISABLE_ANNOTATIONS environment variable

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - DEEPSTACK_URI=http://deepstack-ai:5000/
       - TZ=America/Los_Angeles
       - PROCESS_EXISTING_IMAGES=true
+      - DISABLE_ANNOTATIONS=true
     image: node:alpine
     build:
       context: .

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     volumes:
       - ..:/workspace:cached
       - ../sampleConfiguration/aiinput:/aiinput
-      - localtriggerstorage:/node-deepstackai-trigger
     secrets:
       - triggers
       - mqtt
@@ -52,7 +51,6 @@ services:
 
 volumes:
   localstorage:
-  localtriggerstorage:
 
 secrets:
   triggers:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     "ajvkeywords",
     "bufferutil",
     "cascadia",
+    "cooldown",
     "cooldowns",
     "danecreekphotography",
     "davidanson",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,10 @@
     "Ghhiijjkkllmm",
     "MQTT",
     "NTBA",
+    "aiinput",
     "aimotion",
     "ajvkeywords",
+    "bufferutil",
     "cascadia",
     "cooldowns",
     "danecreekphotography",
@@ -19,7 +21,10 @@
     "esbenp",
     "localstorage",
     "localtriggerstorage",
+    "markdownlint",
+    "mosquitto",
     "mqtts",
+    "postversion",
     "pureimage",
     "streetsidesoftware"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## Unreleased
 
 - Annotated images that show the objects and confidence percentage for things that fired the triggers are now available
-  for Telegram messages and via a built-in web server for other services to use. To enable the annotated image in Telegram
-  messages set the new `annotateImage` property to true on the handler configuration. The annotated images are
-  also exposed via a web server on port `4242` using their original file name, for example `http://localhost:4242/Dog_20200523-075000.jpg`.
-  While this should work without any additional configuration there are new environment variables available to control
-  the web server port as well as retention of the annotated images. By default the images are kept for 60 minutes before
-  being deleted. This can all be disabled by setting the `DISABLE_ANNOTATIONS` environment variable.
+  for Telegram messages. To enable the annotated image in Telegram messages set the new `annotateImage` property to true on
+  the handler configuration. The annotated images are also exposed via a web server on port `4242` using their original file name
+  for use by external, for example `http://localhost:4242/Dog_20200523-075000.jpg`. While this should work without any additional
+  configuration there are new environment variables available to control the web server port as well as retention of
+  the annotated images. By default the images are kept for 60 minutes before being deleted. This can all be disabled by
+  setting the `DISABLE_ANNOTATIONS` environment variable.
   Resolves [issue 187](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/191).
 - Resolve a warning when using Telegram triggers. Resolves [issue 174](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/174).
 - An optional `/node-deepstackai-trigger` mount point exists for future use. Resolves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- Annotated images that show the objects and confidence percentage for things that fired the triggers are now available
+  for Telegram messages and via a built-in web server for other services to use. To enable the annotated image in Telegram
+  messages set the new `annotatedImage` property to true on the handler configuration. The annotated images are
+  exposed on port `4242` by default using their original file name, for example `http://localhost:4242/Dog_20200523-075000.jpg`.
+  While this should work without any additional configuration there are new environment variables available to control
+  the web server port as well as retention of the annotated images. By default the images are kept for 60 minutes before
+  being deleted. This can all be disabled by setting the `DISABLE_ANNOTATIONS` environment variable.
+  Resolves [issue 187](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/191).
 - Resolve a warning when using Telegram triggers. Resolves [issue 174](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/174).
 - An optional `/node-deepstackai-trigger` mount point exists for future use. Resolves
   [issue 191](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/191).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Annotated images that show the objects and confidence percentage for things that fired the triggers are now available
   for Telegram messages. To enable the annotated image in Telegram messages set the new `annotateImage` property to true on
   the handler configuration. The annotated images are also exposed via a web server on port `4242` using their original file name
-  for use by external, for example `http://localhost:4242/Dog_20200523-075000.jpg`. While this should work without any additional
+  for use by external services, for example `http://localhost:4242/Dog_20200523-075000.jpg`. While this should work without any additional
   configuration there are new environment variables available to control the web server port as well as retention of
   the annotated images. By default the images are kept for 60 minutes before being deleted. This can all be disabled by
   setting the `DISABLE_ANNOTATIONS` environment variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Annotated images that show the objects and confidence percentage for things that fired the triggers are now available
   for Telegram messages and via a built-in web server for other services to use. To enable the annotated image in Telegram
-  messages set the new `annotatedImage` property to true on the handler configuration. The annotated images are
-  exposed on port `4242` by default using their original file name, for example `http://localhost:4242/Dog_20200523-075000.jpg`.
+  messages set the new `annotateImage` property to true on the handler configuration. The annotated images are
+  also exposed via a web server on port `4242` using their original file name, for example `http://localhost:4242/Dog_20200523-075000.jpg`.
   While this should work without any additional configuration there are new environment variables available to control
   the web server port as well as retention of the annotated images. By default the images are kept for 60 minutes before
   being deleted. This can all be disabled by setting the `DISABLE_ANNOTATIONS` environment variable.

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       # Change ./path_to_local_ai_images_folder to point to the folder that
       # will have the images to analyze
       - ./path_to_local_ai_images_folder:/aiinput
-      # Leave this unchanged, required for temporary data file storage
-      - localtriggerstorage:/node-deepstackai-trigger
 
     environment:
       # Change this to match the timezone the images are produced in,
@@ -53,7 +51,6 @@ services:
 
 volumes:
   localstorage:
-  localtriggerstorage:
 
 secrets:
   triggers:

--- a/sampleConfiguration/docker-compose.yml
+++ b/sampleConfiguration/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       # annotated images. If you change this you also have to set the same value
       # in the ports: section below.
       - PORT=4242
+      # Uncomment this line to disable the internal web server and
+      # generation of annotated images
+      # - DISABLE_ANNOTATIONS=true
       # This is pre-configured for service-to-service connectivity in
       # Docker. Don't change this unless there is a need to talk to an
       # external DeepStack server somewhere and you know what you are doing.

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -103,7 +103,9 @@ export default class Trigger {
     TriggerManager.incrementTriggeredCount();
 
     // Generate the annotations so it is ready for the other trigger handlers
-    await AnnotationManager.processTrigger(fileName, this, triggeredPredictions);
+    if (!process.env.DISABLE_ANNOTATIONS) {
+      await AnnotationManager.processTrigger(fileName, this, triggeredPredictions);
+    }
 
     // Call all the handlers for the trigger. There is no need to wait for these to finish before proceeding
     WebRequestHandler.processTrigger(fileName, this, triggeredPredictions);

--- a/src/handlers/telegramManager/TelegramManager.ts
+++ b/src/handlers/telegramManager/TelegramManager.ts
@@ -106,9 +106,10 @@ export async function processTrigger(
 
   // Figure out the path to the file to send based on whether
   // annotated images were requested in the config.
-  const imageFileName = trigger.telegramConfig.annotateImage
-    ? LocalStorageManager.mapToLocalStorage(fileName)
-    : fileName;
+  const imageFileName =
+    trigger.telegramConfig.annotateImage && !process.env.DISABLE_ANNOTATIONS
+      ? LocalStorageManager.mapToLocalStorage(fileName)
+      : fileName;
 
   // Send all the messages
   try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,13 +62,20 @@ async function main() {
       );
     }
 
-    // Initialize the web storage
-    await LocalStorageManager.initializeStorage();
-    LocalStorageManager.startBackgroundPurge(purgeInterval, purgeAge);
+    // Initialize the local storage and web server
+    if (!process.env.DISABLE_ANNOTATIONS) {
+      await LocalStorageManager.initializeStorage();
+      LocalStorageManager.startBackgroundPurge(purgeInterval, purgeAge);
+      WebServer.startApp();
+    } else {
+      log.info(
+        "Main",
+        "Annotated images are disabled due to presence of the DISABLE_ANNOTATIONS environment variable.",
+      );
+    }
 
     await TriggerManager.loadConfiguration(["/run/secrets/triggers", "/config/triggers.json"]);
     await TelegramManager.loadConfiguration(["/run/secrets/telegram", "/config/telegram.json"]);
-    WebServer.startApp();
 
     // Start watching
     TriggerManager.startWatching();


### PR DESCRIPTION
# Fixes #226

## Description of changes

Add DISABLE_ANNOTATIONS, which if set to anything disables the internal web server and all image annotation/writing to local storage.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
