### PR TITLE
Add analysis duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- The length of time it takes to analyze an image is now calculated and available via the `analysisDurationMs` property in the default
+  MQTT message. It is also available as a mustache template variable and shown in verbose logging messages. Resolves [issue 242](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/242).
 - MQTT messages now include the trigger's name in the `name` property. Resolves [issue 243](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Configuration#enabling--configuring-pushover).
 - Pushover is now supported as a trigger handler. See the wiki for [how to enable it](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Configuration#enabling--configuring-pushover) and [how to configure it on a trigger](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/Defining-triggers#defining-pushover-handlers). Resolves [issue 232](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/232).
 - Annotated images that show the objects and confidence percentage for things that fired the triggers are now available

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -39,6 +39,7 @@ export function format(
     fileName: optionallyEncode(fileName, urlEncode),
     baseName: optionallyEncode(path.basename(fileName), urlEncode),
     predictions: optionallyEncode(JSON.stringify(predictions), urlEncode),
+    analysisDurationMs: trigger.analysisDuration,
     formattedPredictions: optionallyEncode(formatPredictions(predictions), urlEncode),
     state: "on",
     name: trigger.name,

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -27,6 +27,7 @@ export default class Trigger {
   private _processExisting: boolean;
   private _watcher: chokidar.FSWatcher;
 
+  public analysisDuration: number;
   public receivedDate: Date;
   public name: string;
   public watchPattern: string;
@@ -64,7 +65,9 @@ export default class Trigger {
 
   private async analyzeImage(fileName: string): Promise<IDeepStackPrediction[] | undefined> {
     log.info(`Trigger ${this.name}`, `${fileName}: Analyzing`);
+    const startTime = new Date();
     const analysis = await analyzeImage(fileName);
+    this.analysisDuration = new Date().getTime() - startTime.getTime();
 
     if (!analysis?.success) {
       log.error(`Trigger ${this.name}`, `${fileName}: Analysis failed`);
@@ -72,11 +75,14 @@ export default class Trigger {
     }
 
     if (analysis.predictions.length == 0) {
-      log.info(`Trigger ${this.name}`, `${fileName}: No objects detected`);
+      log.info(`Trigger ${this.name}`, `${fileName}: No objects detected. (${this.analysisDuration} ms)`);
       return undefined;
     }
 
-    log.info(`Trigger ${this.name}`, `${fileName}: Found at least one object in the photo`);
+    log.info(
+      `Trigger ${this.name}`,
+      `${fileName}: Found at least one object in the photo. (${this.analysisDuration} ms)`,
+    );
     return analysis.predictions;
   }
 

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -147,6 +147,7 @@ async function publishDetectionMessage(
     : JSON.stringify({
         fileName,
         name: trigger.name,
+        analysisDurationMs: trigger.analysisDuration,
         basename: path.basename(fileName),
         predictions,
         formattedPredictions: mustacheFormatter.formatPredictions(predictions),


### PR DESCRIPTION
# Fixes #242 

## Description of changes

- Calculate the time it takes to analyze an image
- Send that duration in the default MQTT message
- Write that duration in log messages
- Make the duration available as a mustache variable

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
