### PR TITLE
Publish MQTT messages with the Retain flag set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Setting the `retain` property in `mqtt.conf` to `true` makes all MQTT messages get sent with
-  the retain flag on. Resolves [issue 249](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/247).
+  the retain flag on. Default is `false`. Resolves [issue 249](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/247).
 
 ## Version 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Setting the `retain` property in `mqtt.conf` to `true` makes all MQTT messages get sent with
+  the retain flag on. Resolves [issue 249](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/247).
+
 ## Version 2.1.1
 
 - Fix an incorrect message at startup regarding annotations being enabled when they aren't.

--- a/sampleConfiguration/mqtt.json
+++ b/sampleConfiguration/mqtt.json
@@ -3,5 +3,6 @@
   "uri": "mqtt://mqtt:1883",
   "username": "user",
   "password": "pass",
-  "statusTopic": "aimotion/status"
+  "statusTopic": "aimotion/status",
+  "retain": false
 }

--- a/src/handlers/mqttManager/IMqttManagerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttManagerConfigJson.ts
@@ -8,4 +8,5 @@ export default interface IMqttManagerConfigJson {
   password: string;
   rejectUnauthorized: boolean;
   statusTopic?: string;
+  retain?: boolean;
 }

--- a/src/schemas/mqttManagerConfiguration.schema.json
+++ b/src/schemas/mqttManagerConfiguration.schema.json
@@ -21,6 +21,12 @@
       "type": "string",
       "examples": ["pass"]
     },
+    "retain": {
+      "description": "If true all MQTT messages are published with the retain flag set. Default false.",
+      "type": "boolean",
+      "default": false,
+      "examples": ["true"]
+    },
     "rejectUnauthorized": {
       "description": "Controls whether connections to mqtts:// servers should allow self-signed certificates. Set to false if your MQTT certificates are self-signed and are getting connection errors.",
       "type": "boolean",


### PR DESCRIPTION
Fixes #249

## Description of changes

Add a `retain` option to `mqtt.conf` and then use it on every MQTT message. Default off.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
