### PR TITLE
Split web server enable into its own setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- The internal web server can now be enabled independently from annotated images using the
+  `enableWebServer` setting. It's off by default, and enabled automatically when `enableAnnotations` is on for backwards compatibility reasons. Resolves [issue 265](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/265).
+
 ## Version 3.0.0
 
 ### Breaking changes

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -14,6 +14,7 @@ import ITelegramManagerConfigJson from "./handlers/telegramManager/ITelegramMana
 export let awaitWriteFinish: boolean;
 export let deepstackUri: string;
 export let enableAnnotations: boolean;
+export let enableWebServer: boolean;
 export let mqtt: IMqttManagerConfigJson;
 export let port: number;
 export let processExistingImages: boolean;
@@ -52,6 +53,9 @@ export function loadConfiguration(configFilePaths: string[]): void {
   awaitWriteFinish = settingsConfigJson.awaitWriteFinish ?? false;
   deepstackUri = settingsConfigJson.deepstackUri;
   enableAnnotations = settingsConfigJson.enableAnnotations ?? false;
+  // For backwards compatibility reasons enableWebServer is automatically true
+  // when enableAnnotations is true.
+  enableWebServer = enableAnnotations ? true : settingsConfigJson.enableWebServer ?? false;
   mqtt = settingsConfigJson.mqtt;
   port = settingsConfigJson.port ?? 4242;
   processExistingImages = settingsConfigJson.processExistingImages ?? false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,11 +47,20 @@ async function main() {
       );
     }
 
-    // Initialize the local storage and web server if enabled.
+    // To make things simpler just enable local storage all the time. It won't
+    // do anything harmful if it's unused, just the occasional background purge
+    // that runs.
+    await LocalStorageManager.initializeStorage();
+    LocalStorageManager.startBackgroundPurge();
+
+    // Purely for logging information.
     if (Settings.enableAnnotations) {
-      log.info("Main", "Annotated images are enabled due to presence of the ENABLE_ANNOTATIONS environment variable.");
-      await LocalStorageManager.initializeStorage();
-      LocalStorageManager.startBackgroundPurge();
+      log.info("Main", "Annotated image generation enabled.");
+    }
+
+    // Enable the web server.
+    if (Settings.enableWebServer) {
+      log.info("Main", "Web server enabled.");
       WebServer.startApp();
     }
 

--- a/src/schemas/settings.schema.json
+++ b/src/schemas/settings.schema.json
@@ -27,6 +27,12 @@
       "default": false,
       "examples": [true]
     },
+    "enableWebServer": {
+      "type": "boolean",
+      "description": "Enables the local web server. Disabled by default.",
+      "default": false,
+      "examples": [true]
+    },
     "deepstackUri": {
       "type": "string",
       "description": "The address of the Deepstack AI processing server.",

--- a/src/types/ISettingsConfigJson.ts
+++ b/src/types/ISettingsConfigJson.ts
@@ -10,6 +10,7 @@ export default interface ISettingsConfigJson {
   awaitWriteFinish?: boolean;
   deepstackUri: string;
   enableAnnotations?: boolean;
+  enableWebServer?: boolean;
   mqtt?: IMqttManagerConfigJson;
   port?: number;
   processExistingImages?: boolean;


### PR DESCRIPTION
Fixes #265

## Description of changes

Add a dedicated setting for enabling the web server, but still turn it on automatically when annotations are enabled for backwards compatibility.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
