### PR TITLE
Missing catch for failed DNS on calling Deepstack

### DIFF
--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -59,7 +59,11 @@ export default class Trigger {
   private async analyzeImage(fileName: string): Promise<IDeepStackPrediction[] | undefined> {
     log.verbose(`Trigger ${this.name}`, `${fileName}: Analyzing`);
     const startTime = new Date();
-    const analysis = await analyzeImage(fileName);
+    const analysis = await analyzeImage(fileName).catch(e => {
+      log.warn("Trigger ${this.name}", e);
+      return undefined;
+    });
+
     this.analysisDuration = new Date().getTime() - startTime.getTime();
 
     if (!analysis?.success) {


### PR DESCRIPTION
Fixes #271

## Description of changes

Add a missing catch

## Checklist

Not needed