### PR TITLE
Web server sometimes leaves the port used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Requests to end the system (e.g. via ctrl+c) are handled gracefully now. Resolves [issue 280](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/280).
 - Changes to `settings.json` and `triggers.json` are automatically detected and cause a reload. No need to restart
   the Docker container anymore! Just save the file and the system should notice the change and reload with the new
   configuration. Resolves [issue 278](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/278).

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@
 // See https://github.com/yagop/node-telegram-bot-api/issues/319
 process.env.NTBA_FIX_319 = "true";
 
-import * as AnnotationManager from "./handlers/annotationManager/AnnotationManager";
 import * as chokidar from "chokidar";
 import * as LocalStorageManager from "./LocalStorageManager";
 import * as log from "./Log";
@@ -58,9 +57,9 @@ async function startup(): Promise<void> {
     await LocalStorageManager.initializeStorage();
     LocalStorageManager.startBackgroundPurge();
 
+    // Purely for logging information.
     if (Settings.enableAnnotations) {
       log.info("Main", "Annotated image generation enabled.");
-      await AnnotationManager.initialize();
     }
 
     // Enable the web server.


### PR DESCRIPTION
Fixes #280

## Description of changes

Register for SIGINT and its variants to shut down the filesystem and web server gracefully.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
