### PR TITLE
Unhandled promise rejection when ctrl+C on failed start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
+
 ## Version 4.0.0
 
 ### Breaking changes

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -135,13 +135,17 @@ export async function activateWebTrigger(triggerName: string): Promise<void> {
  * Start all registered triggers watching for changes.
  */
 export function startWatching(): void {
-  _triggers.map(trigger => trigger.startWatching());
+  _triggers?.map(trigger => trigger.startWatching());
 }
 
 /**
  * Stops all registered triggers from watching for changes.
  */
 export async function stopWatching(): Promise<void[]> {
+  if (!_triggers) {
+    return;
+  }
+
   return Promise.all(_triggers.map(trigger => trigger.stopWatching()));
 }
 


### PR DESCRIPTION
Fixes #301

## Description of changes

Check for empty triggers list before trying to stop triggers.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
