### PR TITLE
Switch to node:slim

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,12 +2,12 @@
 # This is most important for git: if git is installed via postCreateCommand it actually isn't there in
 # time for first container creation. VSCode will attempt to copy the .gitconfig file and fail
 # because git isn't installed
-FROM node:alpine
+FROM node:slim
 
 ARG NPM_GLOBAL=/usr/local/share/npm-global
 ARG USERNAME=node
 
-RUN apk --no-cache update && apk --no-cache upgrade && apk --no-cache add tzdata && apk --no-cache add git
+RUN apt-get update && apt-get install -y git
 
 # Set up the npm install directory so it works with the "node" user
 RUN mkdir -p ${NPM_GLOBAL} \
@@ -20,8 +20,8 @@ RUN mkdir -p ${NPM_GLOBAL} \
 # is mounted there the permissions are correct
 RUN mkdir -p /workspace/.git \
     && mkdir -p /node-deepstackai-trigger \
-    && chown -R node:node /workspace/.git \
-    && chown -R node:node /node-deepstackai-trigger
+    && chown -R ${USERNAME}:${USERNAME} /workspace/.git \
+    && chown -R ${USERNAME}:${USERNAME} /node-deepstackai-trigger
 
 ENV CHOKIDAR_USEPOLLING=true
 USER node

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,10 +10,9 @@ services:
   trigger:
     environment:
       - TZ=America/Los_Angeles
-    image: node:alpine
     build:
       context: .
-      dockerfile: Dockerfile # Apply development-only overrides to the base alpine image
+      dockerfile: Dockerfile # Apply development-only overrides to the base image
     depends_on:
       - deepstack-ai
     volumes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
   available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
+- The underlying Linux variant used for the Docker image is now `node:slim`. Resolves [issue 299](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 
 ## Version 4.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This temporary image is used to produce the build.
-FROM node:alpine as build
+FROM node:slim as build
 RUN mkdir -p /home/node/app/fonts && chown -R node:node /home/node/app
 
 WORKDIR /home/node/app
@@ -11,10 +11,7 @@ RUN npm ci --no-optional
 RUN npm run webpack
 
 # This is the final production image
-FROM node:alpine
-# Install tzdata so the timezone can be set correctly in the image via
-# the TZ environment variable.
-RUN apk --no-cache update && apk --no-cache upgrade && apk --no-cache add tzdata
+FROM node:slim
 
 # Pre-create the temporary storage folder so it has the right user
 # permissions on it after volume mount


### PR DESCRIPTION
# Fixes #299 

## Description of changes

Update Docker base image to `node:slim` instead of `node:alpine`.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
