### PR TITLE
Add support for per-trigger statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Per-trigger statistics are now sent in each MQTT message. The triggered count and analyzed file count are included,
+  as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
+  available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 
 ## Version 4.0.0

--- a/src/MustacheFormatter.ts
+++ b/src/MustacheFormatter.ts
@@ -17,6 +17,10 @@ export function formatPredictions(predictions: IDeepStackPrediction[]): string {
     .join(", ");
 }
 
+export function formatStatistics(triggeredCount: number, analyzedFilesCount: number): string {
+  return `Triggered count: ${triggeredCount} Analyzed file count: ${analyzedFilesCount}`;
+}
+
 function optionallyEncode(value: string, urlEncode: boolean): string {
   return urlEncode ? encodeURIComponent(value) : value;
 }
@@ -41,6 +45,12 @@ export function format(
     predictions: optionallyEncode(JSON.stringify(predictions), urlEncode),
     analysisDurationMs: trigger.analysisDuration,
     formattedPredictions: optionallyEncode(formatPredictions(predictions), urlEncode),
+    formattedStatistics: optionallyEncode(
+      formatStatistics(trigger.triggeredCount, trigger.analyzedFilesCount),
+      urlEncode,
+    ),
+    triggeredCount: trigger.triggeredCount,
+    analyzedFilesCount: trigger.analyzedFilesCount,
     state: "on",
     name: trigger.name,
   };

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -31,20 +31,29 @@ export default class Trigger {
   private _watcher: chokidar.FSWatcher;
 
   public analysisDuration: number;
-  public receivedDate: Date;
-  public name: string;
-  public watchPattern: string;
-  public watchObjects?: string[];
-  public triggerUris?: string[];
-  public snapshotUri?: string;
-  public enabled = true;
+  /**
+   * Provides a running total of the number of files analyzed.
+   * Use the incrementAnalyzedFiles() method to update the total.
+   */
+  public analyzedFilesCount = 0;
   public cooldownTime: number;
+  public enabled = true;
+  public name: string;
+  public masks: Rect[];
+  public receivedDate: Date;
+  public snapshotUri?: string;
   public threshold: {
     minimum: number;
     maximum: number;
   };
-
-  public masks: Rect[];
+  /**
+   * Provides a running total of the number of times an image caused triggers
+   * to fire. Use the incrementTriggeredCount() method to update the total.
+   */
+  public triggeredCount = 0;
+  public triggerUris?: string[];
+  public watchPattern: string;
+  public watchObjects?: string[];
 
   // Handler configurations
   public webRequestHandlerConfig: WebRequestConfig;
@@ -95,6 +104,7 @@ export default class Trigger {
    */
   public async processImage(fileName: string): Promise<void> {
     TriggerManager.incrementAnalyzedFilesCount();
+    this.analyzedFilesCount += 1;
 
     // Don't process old files.
     if (!(await this.passesDateTest(fileName))) return;
@@ -116,6 +126,7 @@ export default class Trigger {
 
     // At this point a prediction matched so increment the count.
     TriggerManager.incrementTriggeredCount();
+    this.triggeredCount += 1;
 
     // Generate the annotations so it is ready for the other trigger handlers. This does
     // nothing if annotations are disabled.

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -124,7 +124,10 @@ async function publishDetectionMessage(
         basename: path.basename(fileName),
         predictions,
         formattedPredictions: mustacheFormatter.formatPredictions(predictions),
+        formattedStatistics: mustacheFormatter.formatStatistics(trigger.triggeredCount, trigger.analyzedFilesCount),
         state: "on",
+        analyzedFilesCount: trigger.analyzedFilesCount,
+        triggerCount: trigger.triggeredCount,
       });
 
   return await _mqttClient.publish(messageConfig.topic, detectionPayload, { retain: _retain });
@@ -153,6 +156,7 @@ export async function publishStatisticsMessage(
         state: "online",
         triggerCount,
         analyzedFilesCount,
+        formattedStatistics: mustacheFormatter.formatStatistics(triggerCount, analyzedFilesCount),
       }),
       { retain: _retain },
     ),


### PR DESCRIPTION
# Fixes #306

## Description of changes

- Add per-trigger statistics to the MQTT messages
- Add per-trigger statistics to mustache templates.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
