### PR TITLE
Add REST API for statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Per-trigger statistics are now sent in each MQTT message. The triggered count and analyzed file count are included,
   as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
   available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
+- Statistics can be read and reset via new REST APIs. Overall statistics are available at `/statistics` and
+  per-trigger statistics are available at `/statistics/triggerName`. See the API documentation for more information.
+  Resolves [issue 307](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/307).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 - The underlying Linux variant used for the Docker image is now `node:slim`. Resolves [issue 299](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
   as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
   available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Statistics can be read and reset via new REST APIs. Overall statistics are available at `/statistics` and
-  per-trigger statistics are available at `/statistics/triggerName`. See the API documentation for more information.
-  Resolves [issue 307](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/307).
+  per-trigger statistics are available at `/statistics/triggerName`. [See the API documentation for more information](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/REST-API). Resolves [issue 307](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/307).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 - The underlying Linux variant used for the Docker image is now `node:slim`. Resolves [issue 299](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -10,6 +10,7 @@ import express from "express";
 import motionRouter from "./routes/motion";
 import path from "path";
 import { Server } from "http";
+import statisticsRouter from "./routes/statistics";
 
 const app = express();
 let server: Server;
@@ -19,6 +20,7 @@ export function startApp(): void {
   app.use("/", express.static(annotatedImagePath));
   app.use("/annotations", express.static(annotatedImagePath));
   app.use("/motion", motionRouter);
+  app.use("/statistics", statisticsRouter);
 
   try {
     server = app.listen(Settings.port, () => log.info("Web server", `Listening at http://localhost:${Settings.port}`));

--- a/src/controllers/statistics.ts
+++ b/src/controllers/statistics.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import express from "express";
+import * as log from "../Log";
+import * as TriggerManager from "../TriggerManager";
+
+export function getTriggerStatistics(req: express.Request, res: express.Response): void {
+  log.verbose("Web server", `Received statistics request for ${req.params.triggerName}.`);
+
+  res.json(TriggerManager.getTriggerStatistics(req.params.triggerName));
+}
+
+export function resetTriggerStatistics(req: express.Request, res: express.Response): void {
+  log.verbose("Web server", `Received statistics reset request for ${req.params.triggerName}.`);
+
+  res.json(TriggerManager.resetTriggerStatistics(req.params.triggerName));
+}
+
+export function getOverallStatistics(req: express.Request, res: express.Response): void {
+  log.verbose("Web server", `Received overall statistics request.`);
+
+  res.json(TriggerManager.getOverallStatistics());
+}
+
+export function resetOverallStatistics(req: express.Request, res: express.Response): void {
+  log.verbose("Web server", `Received overall statistics reset request.`);
+
+  res.json(TriggerManager.resetOverallStatistics());
+}

--- a/src/routes/statistics.ts
+++ b/src/routes/statistics.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import express from "express";
+import * as statisticsController from "../controllers/statistics";
+
+const router = express.Router();
+
+// Set up the routes
+router.get("/trigger/:triggerName", statisticsController.getTriggerStatistics);
+router.get("/trigger/:triggerName/reset", statisticsController.resetTriggerStatistics);
+router.get("/", statisticsController.getOverallStatistics);
+router.get("/reset", statisticsController.resetOverallStatistics);
+
+// Export it for use elsewhere
+export default router;

--- a/src/types/ITriggerStatistics.ts
+++ b/src/types/ITriggerStatistics.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export default interface ITriggerStatistics {
+  triggeredCount: number;
+  analyzedFilesCount: number;
+}


### PR DESCRIPTION
# Fixes #307

## Description of changes

- New APIs for getting and resetting overall and per-trigger statistics.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
