### PR TITLE
Add clearing statistics via MQTT

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
     "localtriggerstorage",
     "markdownlint",
     "mosquitto",
+    "mqttpacket",
     "mqtts",
     "mutli",
     "pianobar",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- `statusTopic` can no longer be set on the mqtt configuration in `settings.json`. Overall status messages
+  are always sent to the `node-deepstackai-trigger/status` topic. This change aligns the status topic messages
+  with the new MQTT messages that the system listens to for resetting statistics.
+
+### Non-breaking changes
+
 - Per-trigger statistics are now sent in each MQTT message. The triggered count and analyzed file count are included,
   as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
   available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
+- Statistics can be reset by publishing specific MQTT messages to the `node-deepstackai-trigger/statistics` topics
+  and sub-topics. Resolves [issue 308](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Statistics can be read and reset via new REST APIs. Overall statistics are available at `/statistics` and
   per-trigger statistics are available at `/statistics/triggerName`. [See the API documentation for more information](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/REST-API). Resolves [issue 307](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/307).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).

--- a/src/MqttRouter.ts
+++ b/src/MqttRouter.ts
@@ -11,13 +11,12 @@ const _statusResetTopic = "node-deepstack-ai/statistics/reset";
 const _triggerResetTopic = "node-deepstack-ai/statistics/trigger/reset";
 
 export async function initialize(): Promise<void> {
-  const client = MqttManager.client;
-
   if (!MqttManager.isEnabled) {
     return;
   }
 
-  // Register for overall statistic reset
+  const client = MqttManager.client;
+
   try {
     log.info("Mqtt router", `Subscribing to ${_statusResetTopic}.`);
     await client.subscribe(_statusResetTopic);

--- a/src/MqttRouter.ts
+++ b/src/MqttRouter.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as log from "./Log";
+import * as MqttManager from "./handlers/mqttManager/MqttManager";
+import * as TriggerManager from "./TriggerManager";
+
+const statusResetTopic = "node-deepstack-ai/statistics/reset";
+const triggerResetTopic = "node-deepstack-ai/statistics/trigger/reset";
+
+export async function initialize(): Promise<void> {
+  const client = MqttManager.client;
+
+  if (!MqttManager.isEnabled) {
+    return;
+  }
+
+  // Register for overall statistic reset
+  try {
+    log.info("Mqtt router", `Subscribing to ${statusResetTopic}.`);
+    await client.subscribe(statusResetTopic);
+
+    log.info("Mqtt router", `Subscribing to ${triggerResetTopic}.`);
+    await client.subscribe(triggerResetTopic);
+
+    client.on("message", (topic, message) => processReceivedMessage(topic, message));
+  } catch (e) {
+    log.warn("Mqtt router", `Unable to subscribe to topics: ${e}`);
+  }
+}
+
+/**
+ * Takes a topic and a message and maps it to the right action
+ * @param topic The topic received
+ * @param message The message received
+ */
+function processReceivedMessage(topic: string, message: Buffer): void {
+  log.info("Mqtt router", `Received message: ${statusResetTopic}`);
+
+  if (topic === statusResetTopic) {
+    log.verbose("Mqtt router", `Received overall statistics reset request.`);
+    TriggerManager.resetOverallStatistics();
+  }
+
+  if (topic === triggerResetTopic) {
+    log.verbose("Mqtt router", `Received trigger statistics reset request.`);
+    let triggerName: string;
+
+    try {
+      triggerName = JSON.parse(message.toString())?.name;
+    } catch (e) {
+      log.warn("Mqtt router", `Unable to process incoming message: ${e}`);
+      return;
+    }
+
+    if (!triggerName) {
+      log.warn("Mqtt router", `Received a statistics reset request but no trigger name was provided`);
+    }
+
+    TriggerManager.resetTriggerStatistics(triggerName);
+  }
+}

--- a/src/MqttRouter.ts
+++ b/src/MqttRouter.ts
@@ -7,8 +7,8 @@ import * as log from "./Log";
 import * as MqttManager from "./handlers/mqttManager/MqttManager";
 import * as TriggerManager from "./TriggerManager";
 
-const statusResetTopic = "node-deepstack-ai/statistics/reset";
-const triggerResetTopic = "node-deepstack-ai/statistics/trigger/reset";
+const _statusResetTopic = "node-deepstack-ai/statistics/reset";
+const _triggerResetTopic = "node-deepstack-ai/statistics/trigger/reset";
 
 export async function initialize(): Promise<void> {
   const client = MqttManager.client;
@@ -19,11 +19,11 @@ export async function initialize(): Promise<void> {
 
   // Register for overall statistic reset
   try {
-    log.info("Mqtt router", `Subscribing to ${statusResetTopic}.`);
-    await client.subscribe(statusResetTopic);
+    log.info("Mqtt router", `Subscribing to ${_statusResetTopic}.`);
+    await client.subscribe(_statusResetTopic);
 
-    log.info("Mqtt router", `Subscribing to ${triggerResetTopic}.`);
-    await client.subscribe(triggerResetTopic);
+    log.info("Mqtt router", `Subscribing to ${_triggerResetTopic}.`);
+    await client.subscribe(_triggerResetTopic);
 
     client.on("message", (topic, message) => processReceivedMessage(topic, message));
   } catch (e) {
@@ -37,14 +37,14 @@ export async function initialize(): Promise<void> {
  * @param message The message received
  */
 function processReceivedMessage(topic: string, message: Buffer): void {
-  log.info("Mqtt router", `Received message: ${statusResetTopic}`);
+  log.info("Mqtt router", `Received message: ${_statusResetTopic}`);
 
-  if (topic === statusResetTopic) {
+  if (topic === _statusResetTopic) {
     log.verbose("Mqtt router", `Received overall statistics reset request.`);
     TriggerManager.resetOverallStatistics();
   }
 
-  if (topic === triggerResetTopic) {
+  if (topic === _triggerResetTopic) {
     log.verbose("Mqtt router", `Received trigger statistics reset request.`);
     let triggerName: string;
 

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -171,7 +171,7 @@ export function incrementAnalyzedFilesCount(): void {
  * @returns The triggers new statistics
  */
 export function getTriggerStatistics(triggerName: string): ITriggerStatistics {
-  return _triggers
+  return triggers
     .find(trigger => {
       return trigger.name.toLowerCase() === triggerName.toLowerCase();
     })
@@ -201,11 +201,11 @@ export function resetTriggerStatistics(triggerName: string): ITriggerStatistics 
  * Returns the overall statistics
  */
 export function getAllTriggerStatistics(): ITriggerStatistics[] {
-  if (!_triggers) {
+  if (!triggers) {
     return;
   }
 
-  return _triggers.map(trigger => {
+  return triggers.map(trigger => {
     return trigger.getStatistics();
   });
 }
@@ -215,11 +215,11 @@ export function getAllTriggerStatistics(): ITriggerStatistics[] {
  * @returns The new trigger statistics
  */
 export function resetAllTriggerStatistics(): ITriggerStatistics[] {
-  if (!_triggers) {
+  if (!triggers) {
     return;
   }
 
-  return _triggers.map(trigger => {
+  return triggers.map(trigger => {
     return trigger.resetStatistics();
   });
 }

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -31,7 +31,7 @@ export let analyzedFilesCount = 0;
 /**
  * The list of all the triggers managed by this.
  */
-let _triggers: Trigger[];
+export let triggers: Trigger[];
 
 /**
  * Takes a path to a configuration file and loads all of the triggers from it.
@@ -43,7 +43,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
   let triggerConfigJson: ITriggerConfigJson;
 
   // Reset triggers to empty in case this is getting hot reloaded
-  _triggers = [];
+  triggers = [];
 
   // Look through the list of possible loadable config files and try loading
   // them in turn until a valid one is found.
@@ -68,7 +68,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
 
   log.info("Triggers", `Loaded configuration from ${loadedConfigFilePath}`);
 
-  _triggers = triggerConfigJson.triggers.map(triggerJson => {
+  triggers = triggerConfigJson.triggers.map(triggerJson => {
     log.info("Triggers", `Loaded configuration for ${triggerJson.name}`);
     const configuredTrigger = new Trigger({
       cooldownTime: triggerJson.cooldownTime,
@@ -118,7 +118,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
 export async function activateWebTrigger(triggerName: string): Promise<void> {
   // Find the trigger to activate. Do it case insensitive to avoid annoying
   // errors when the trigger name is capitalized slightly differently.
-  const triggerToActivate = _triggers.find(trigger => {
+  const triggerToActivate = triggers.find(trigger => {
     return trigger.name.toLowerCase() === triggerName.toLowerCase();
   });
 
@@ -137,18 +137,18 @@ export async function activateWebTrigger(triggerName: string): Promise<void> {
  * Start all registered triggers watching for changes.
  */
 export function startWatching(): void {
-  _triggers?.map(trigger => trigger.startWatching());
+  triggers?.map(trigger => trigger.startWatching());
 }
 
 /**
  * Stops all registered triggers from watching for changes.
  */
 export async function stopWatching(): Promise<void[]> {
-  if (!_triggers) {
+  if (!triggers) {
     return;
   }
 
-  return Promise.all(_triggers.map(trigger => trigger.stopWatching()));
+  return Promise.all(triggers.map(trigger => trigger.stopWatching()));
 }
 
 /**
@@ -170,7 +170,7 @@ export function incrementAnalyzedFilesCount(): void {
  * @param triggerName The name of the trigger to get the statistics for
  */
 export function getTriggerStatistics(triggerName: string): ITriggerStatistics {
-  const trigger = _triggers.find(trigger => {
+  const trigger = triggers.find(trigger => {
     return trigger.name.toLowerCase() === triggerName.toLowerCase();
   });
 
@@ -189,7 +189,7 @@ export function getTriggerStatistics(triggerName: string): ITriggerStatistics {
  * @param triggerName The name of the trigger to reset the statistics for
  */
 export function resetTriggerStatistics(triggerName: string): ITriggerStatistics {
-  const trigger = _triggers.find(trigger => {
+  const trigger = triggers.find(trigger => {
     return trigger.name.toLowerCase() === triggerName.toLowerCase();
   });
 

--- a/src/handlers/mqttManager/IMqttManagerConfigJson.ts
+++ b/src/handlers/mqttManager/IMqttManagerConfigJson.ts
@@ -7,7 +7,6 @@ export default interface IMqttManagerConfigJson {
   password: string;
   rejectUnauthorized: boolean;
   retain?: boolean;
-  statusTopic?: string;
   uri: string;
   username: string;
 }

--- a/src/handlers/mqttManager/MqttHandlerConfig.ts
+++ b/src/handlers/mqttManager/MqttHandlerConfig.ts
@@ -8,7 +8,6 @@ export default class MqttHandlerConfig {
   public topic?: string;
   public messages: MqttMessageConfig[];
   public enabled: boolean;
-  public statusTopic?: string;
 
   constructor(init?: Partial<MqttHandlerConfig>) {
     Object.assign(this, init);

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -15,7 +15,8 @@ import Trigger from "../../Trigger";
 export let client: MQTT.AsyncClient;
 export let isEnabled = false;
 export let retain = false;
-export let statusTopic = "node-deepstackai-trigger/status";
+
+const _statusTopic = "node-deepstackai-trigger/status";
 
 const _timers = new Map<string, NodeJS.Timeout>();
 
@@ -47,7 +48,7 @@ export async function initialize(): Promise<void> {
     clientId: "node-deepstackai-trigger",
     rejectUnauthorized: settings.rejectUnauthorized ?? true,
     will: {
-      topic: statusTopic,
+      topic: _statusTopic,
       payload: JSON.stringify({ state: "offline" }),
       qos: 2,
       retain: retain,
@@ -178,7 +179,7 @@ export async function publishStatisticsMessage(
 
   return [
     await client.publish(
-      statusTopic,
+      _statusTopic,
       JSON.stringify({
         // Ensures the status still reflects as up and running for people
         // that have an MQTT binary sensor in Home Assistant
@@ -201,7 +202,7 @@ export async function publishServerState(state: string, details?: string): Promi
     return;
   }
 
-  return client.publish(statusTopic, JSON.stringify({ state, details }), { retain: retain });
+  return client.publish(_statusTopic, JSON.stringify({ state, details }), { retain: retain });
 }
 
 /**

--- a/src/handlers/mqttManager/MqttManager.ts
+++ b/src/handlers/mqttManager/MqttManager.ts
@@ -12,10 +12,10 @@ import MqttMessageConfig from "./MqttMessageConfig";
 import path from "path";
 import Trigger from "../../Trigger";
 
-let _isEnabled = false;
-let _mqttClient: MQTT.AsyncClient;
-let _retain = false;
-let _statusTopic = "node-deepstackai-trigger/status";
+export let client: MQTT.AsyncClient;
+export let isEnabled = false;
+export let retain = false;
+export let statusTopic = "node-deepstackai-trigger/status";
 
 const _timers = new Map<string, NodeJS.Timeout>();
 
@@ -29,35 +29,31 @@ export async function initialize(): Promise<void> {
   }
 
   // The enabled setting is true by default
-  _isEnabled = settings.enabled ?? true;
+  isEnabled = settings.enabled ?? true;
 
-  if (!_isEnabled) {
+  if (!isEnabled) {
     log.info("MQTT", "MQTT is disabled via settings.");
     return;
   }
 
-  if (settings.statusTopic) {
-    _statusTopic = settings.statusTopic;
-  }
-
   if (settings.retain) {
-    _retain = settings.retain;
+    retain = settings.retain;
     log.info("MQTT", "Retain flag set in configuration. All messages will be published with retain turned on.");
   }
 
-  _mqttClient = await MQTT.connectAsync(settings.uri, {
+  client = await MQTT.connectAsync(settings.uri, {
     username: settings.username,
     password: settings.password,
     clientId: "node-deepstackai-trigger",
     rejectUnauthorized: settings.rejectUnauthorized ?? true,
     will: {
-      topic: _statusTopic,
+      topic: statusTopic,
       payload: JSON.stringify({ state: "offline" }),
       qos: 2,
-      retain: _retain,
+      retain: retain,
     },
   }).catch(e => {
-    _isEnabled = false;
+    isEnabled = false;
     throw new Error(`[MQTT] Unable to connect: ${e.message}`);
   });
 
@@ -70,7 +66,7 @@ export async function processTrigger(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   predictions: IDeepStackPrediction[],
 ): Promise<MQTT.IPublishPacket[]> {
-  if (!_isEnabled) {
+  if (!isEnabled) {
     return [];
   }
 
@@ -130,7 +126,7 @@ async function publishDetectionMessage(
         triggerCount: trigger.triggeredCount,
       });
 
-  return await _mqttClient.publish(messageConfig.topic, detectionPayload, { retain: _retain });
+  return await client.publish(messageConfig.topic, detectionPayload, { retain: retain });
 }
 
 /**
@@ -153,14 +149,14 @@ export async function publishTriggerStatisticsMessage(trigger: Trigger): Promise
   // Send just the statistics
   return Promise.all(
     trigger.mqttHandlerConfig?.messages.map(message => {
-      return _mqttClient.publish(
+      return client.publish(
         message.topic,
         JSON.stringify({
           formattedStatistics: mustacheFormatter.formatStatistics(trigger.triggeredCount, trigger.analyzedFilesCount),
           analyzedFilesCount: trigger.analyzedFilesCount,
           triggerCount: trigger.triggeredCount,
         }),
-        { retain: _retain },
+        { retain: retain },
       );
     }),
   );
@@ -176,13 +172,13 @@ export async function publishStatisticsMessage(
   analyzedFilesCount: number,
 ): Promise<MQTT.IPublishPacket[]> {
   // Don't send anything if MQTT isn't enabled
-  if (!_mqttClient) {
+  if (!client) {
     return [];
   }
 
   return [
-    await _mqttClient.publish(
-      _statusTopic,
+    await client.publish(
+      statusTopic,
       JSON.stringify({
         // Ensures the status still reflects as up and running for people
         // that have an MQTT binary sensor in Home Assistant
@@ -191,7 +187,7 @@ export async function publishStatisticsMessage(
         analyzedFilesCount,
         formattedStatistics: mustacheFormatter.formatStatistics(triggerCount, analyzedFilesCount),
       }),
-      { retain: _retain },
+      { retain: retain },
     ),
   ];
 }
@@ -201,11 +197,11 @@ export async function publishStatisticsMessage(
  */
 export async function publishServerState(state: string, details?: string): Promise<MQTT.IPublishPacket> {
   // Don't do anything if the MQTT client wasn't configured
-  if (!_mqttClient) {
+  if (!client) {
     return;
   }
 
-  return _mqttClient.publish(_statusTopic, JSON.stringify({ state, details }), { retain: _retain });
+  return client.publish(statusTopic, JSON.stringify({ state, details }), { retain: retain });
 }
 
 /**
@@ -213,5 +209,5 @@ export async function publishServerState(state: string, details?: string): Promi
  * @param topic The topic to publish the message on
  */
 async function publishOffEvent(topic: string): Promise<MQTT.IPublishPacket> {
-  return await _mqttClient.publish(topic, JSON.stringify({ state: "off" }), { retain: _retain });
+  return await client.publish(topic, JSON.stringify({ state: "off" }), { retain: retain });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import * as chokidar from "chokidar";
 import * as LocalStorageManager from "./LocalStorageManager";
 import * as log from "./Log";
 import * as MqttManager from "./handlers/mqttManager/MqttManager";
+import * as MqttRouter from "./MqttRouter";
 import * as PushbulletManager from "./handlers/pushbulletManager/PushbulletManager";
 import * as PushoverManager from "./handlers/pushoverManager/PushoverManager";
 import * as Settings from "./Settings";
@@ -78,6 +79,9 @@ async function startup(): Promise<void> {
     await PushbulletManager.initialize();
     await PushoverManager.initialize();
     await TelegramManager.initialize();
+
+    // Start listening for MQTT events
+    await MqttRouter.initialize();
 
     // Start watching
     TriggerManager.startWatching();

--- a/src/schemas/mqttManagerConfiguration.schema.json
+++ b/src/schemas/mqttManagerConfiguration.schema.json
@@ -34,12 +34,6 @@
       "default": true,
       "examples": ["false"]
     },
-    "statusTopic": {
-      "description": "Topic status messages are published to.",
-      "type": "string",
-      "default": "node-deepstackai-trigger/status",
-      "examples": ["aimotion/status"]
-    },
     "enabled": {
       "description": "Enables MQTT events.",
       "type": "boolean",


### PR DESCRIPTION
Fixes #308

## Description of changes

- Register to listen for various MQTT topics to clear stats
- Remove the ability to set the statusTopic in mqtt settings

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
