### PR TITLE
Move the location of MQTT statistics messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 
 ### Non-breaking changes
 
-- Per-trigger statistics are now sent in each MQTT message. The triggered count and analyzed file count are included,
-  as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also
-  available as variables for mustache templates. Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
+- Per-trigger statistics are now sent in new MQTT messages published to the `node-deepstackai-trigger/statistics`
+  topic. The trigger name, triggered count and analyzed file count are included, as well as a formatted string version suitable for presentation to a user. The per-trigger statistics are also available as variables for mustache templates.
+  Resolves [issue 306](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Statistics can be reset by publishing specific MQTT messages to the `node-deepstackai-trigger/statistics` topics
   and sub-topics. Resolves [issue 308](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/306).
 - Statistics can be read and reset via new REST APIs. Overall statistics are available at `/statistics` and

--- a/src/MqttRouter.ts
+++ b/src/MqttRouter.ts
@@ -7,8 +7,8 @@ import * as log from "./Log";
 import * as MqttManager from "./handlers/mqttManager/MqttManager";
 import * as TriggerManager from "./TriggerManager";
 
-const _statusResetTopic = "node-deepstack-ai/statistics/reset";
-const _triggerResetTopic = "node-deepstack-ai/statistics/trigger/reset";
+const _statusResetTopic = "node-deepstackai-trigger/statistics/reset";
+const _triggerResetTopic = "node-deepstackai-trigger/statistics/trigger/reset";
 
 export async function initialize(): Promise<void> {
   if (!MqttManager.isEnabled) {


### PR DESCRIPTION
Fixes #315

## Description of changes

- All statistics publish under the same topic, not the one specified for motion on the trigger.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
