### PR TITLE
Triggers can be activated via MQTT now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Statistics can be read and reset via new REST APIs. Overall statistics are available at `/statistics` and
   per-trigger statistics are available at `/statistics/triggerName`. Statistics for all triggers can be retrieved from
   `/statistics/all`. [See the API documentation for more information](https://github.com/danecreekphotography/node-deepstackai-trigger/wiki/REST-API). Resolves [issue 307](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/307) and [issue 311](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/311).
+- Triggers can be activated by sending `node-deepstackai-trigger/motion` MQTT messages with the name of the trigger
+  in the message. This is similar to activating a trigger via the REST API and results in the trigger attempting
+  to download a snapshot from the `snapshotUri` specified in the trigger's configuration. Resolves [issue 314](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 - Shutting down the system after a failed launch no longer throws an error. Resolves [issue 301](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 - The underlying Linux variant used for the Docker image is now `node:slim`. Resolves [issue 299](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).
 - Pushbullet is now included in the settings JSON schema. Resolves [issue 316](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/291).

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -362,6 +362,11 @@ export default class Trigger {
       log.warn(`Trigger ${this.name}`, `Unable to download snapshot from ${this.snapshotUri}: ${e}`);
       return;
     });
+
+    if (!response) {
+      return;
+    }
+
     await fsPromise.writeFile(localStoragePath, response).catch(e => {
       log.warn(`Trigger ${this.name}`, `Unable to save snapshot: ${e}`);
       return;

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -130,6 +130,12 @@ export async function activateWebTrigger(triggerName: string): Promise<void> {
   log.verbose("Trigger manager", `Activating ${triggerToActivate.name} based on a web request.`);
 
   const fileName = await triggerToActivate.downloadWebImage();
+
+  // If no file name came back that means download failed for reason so just give up.
+  if (!fileName) {
+    return;
+  }
+
   return triggerToActivate.processImage(fileName);
 }
 


### PR DESCRIPTION
# Fixes #314

## Description of changes

- MQTT messages can now activate a trigger
- Fixed a bug with error handling when snapshotUri can't be accessed

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
