### PR TITLE
Print out count of images in /aiinput on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Log messages are printed on startup to help confirm the image folder was mounted correctly with Docker.
+  Resolves [issue 330](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/330).
 - Web server now shuts down properly when reloading settings. Resolves [issue 323](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/323).
 - Startup is now re-attempted if there are any failures during launch. Each re-attempt is 30 seconds
   apart and five re-attempts will happen before things are assumed to just be completely broken.

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -276,7 +276,7 @@ export function verifyTriggerWatchLocations(): boolean {
       return true;
     }
 
-    log.info("Trigger manager", `There are ${files.length} images waiting in ${watchFolder} for ${trigger.name}.`);
+    log.verbose("Trigger manager", `There are ${files.length} images waiting in ${watchFolder} for ${trigger.name}.`);
     return false;
   });
 

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -7,7 +7,9 @@ import * as log from "./Log";
 import * as MQTTManager from "./handlers/mqttManager/MqttManager";
 
 import ITriggerConfigJson from "./types/ITriggerConfigJson";
+import * as fs from "fs";
 import MqttHandlerConfig from "./handlers/mqttManager/MqttHandlerConfig";
+import path from "path";
 import PushbulletConfig from "./handlers/pushbulletManager/PushbulletConfig";
 import PushoverConfig from "./handlers/pushoverManager/PushoverConfig";
 import Rect from "./Rect";
@@ -251,4 +253,33 @@ export function resetOverallStatistics(): ITriggerStatistics {
 
   MQTTManager.publishStatisticsMessage(triggeredCount, analyzedFilesCount);
   return getOverallStatistics();
+}
+
+/**
+ * Checks the watch folder on each trigger to see if there are images in it. If
+ * not throws a warning.
+ * @returns True if all the watch locations are valid, false otherwise.
+ */
+export function verifyTriggerWatchLocations(): boolean {
+  const invalidWatchLocations = triggers?.filter(trigger => {
+    const watchFolder = path.dirname(trigger.watchPattern);
+
+    let files: string[];
+
+    try {
+      files = fs.readdirSync(watchFolder);
+    } catch (e) {
+      log.warn(
+        "Trigger manager",
+        `Unable to read contents of watch folder ${watchFolder} for trigger ${trigger.name}. Check and make sure the image folder is mounted properly. ${e}`,
+      );
+      return true;
+    }
+
+    log.info("Trigger manager", `There are ${files.length} images waiting in ${watchFolder} for ${trigger.name}.`);
+    return false;
+  });
+
+  // If no invalid watch locations were found then we're good to go and return true
+  return invalidWatchLocations.length == 0;
 }


### PR DESCRIPTION
Fixes #330

## Description of changes

- Stop startup if any of the watch folders don't exist
- Log errors appropriately
- If the watch folders do exist log the count of images in it

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
