### PR TITLE
Relax startup check for watchObject folders

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,5 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
-      - run: npm audit
       - run: npm test
       - run: npm run webpack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+- Relax the test for valid watchObject folders at startup. If the path has globs in it a warning will still get
+  thrown but system startup will proceed. Resolves [issue 342](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/342).
+
 ## Version 5.1.0
 
 - Warnings are now shown when `annotateImage` is `true` for a trigger handler but `enableAnnotations` wasn't set

--- a/src/main.ts
+++ b/src/main.ts
@@ -81,11 +81,11 @@ async function startup(): Promise<void> {
       WebServer.startApp();
     }
 
-    // Load the trigger configuration.
+    // Load the trigger configuration. Verifying the location is just a quick check for basic
+    // mounting issues. It doesn't stop the startup of the system since globs are valid in
+    // watchObject paths and that's not something that can easily be verified.
     triggersFilePath = TriggerManager.loadConfiguration(["/run/secrets/triggers", "/config/triggers.json"]);
-    if (!TriggerManager.verifyTriggerWatchLocations()) {
-      throw Error(`Unable to access one or more watch locations.`);
-    }
+    TriggerManager.verifyTriggerWatchLocations();
 
     // Initialize the other handler managers. MQTT got done earlier
     // since it does double-duty and sends overall status messages for the system.
@@ -179,11 +179,11 @@ async function hotLoadTriggers(path: string) {
   // Shut down things that are running
   await TriggerManager.stopWatching();
 
+  // Load the trigger configuration. Verifying the location is just a quick check for basic
+  // mounting issues. It doesn't stop the startup of the system since globs are valid in
+  // watchObject paths and that's not something that can easily be verified.
   TriggerManager.loadConfiguration([path]);
-  if (!TriggerManager.verifyTriggerWatchLocations()) {
-    log.warn("Main", `Unable to access one or more watch locations.`);
-    return;
-  }
+  TriggerManager.verifyTriggerWatchLocations();
 
   TriggerManager.startWatching();
 }


### PR DESCRIPTION
Fixes #342

## Description of changes

- Remove the startup halt if watchObject folders can't be verified.

## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
