### PR TITLE
Retrieve image for MQTT when annotations are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+- The original image that caused a trigger to fire is now stored temporarily and available for
+  use via the built-in web server. The images are available in the `/originals` folder
+  with the original filename. Resolves [issue 350](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/350).
+
 ## Version 5.1.1
 
 - Relax the test for valid watchObject folders at startup. If the path has globs in it a warning will still get

--- a/src/LocalStorageManager.ts
+++ b/src/LocalStorageManager.ts
@@ -13,6 +13,7 @@ import { promises as fsPromise } from "fs";
 export enum Locations {
   Annotations = "annotations",
   Snapshots = "snapshots",
+  Originals = "originals",
 }
 
 /**
@@ -38,6 +39,7 @@ export async function initializeStorage(): Promise<void> {
 
   await mkdirp(path.join(localStoragePath, Locations.Annotations));
   await mkdirp(path.join(localStoragePath, Locations.Snapshots));
+  await mkdirp(path.join(localStoragePath, Locations.Originals));
 }
 
 /**
@@ -97,6 +99,12 @@ async function purgeOldFiles(): Promise<void> {
 
   // Now do snapshots.
   purgeDir = path.join(localStoragePath, Locations.Snapshots);
+  await Promise.all(
+    (await fsPromise.readdir(purgeDir)).map(async fileName => await purgeFile(path.join(purgeDir, fileName))),
+  );
+
+  // Now do originals.
+  purgeDir = path.join(localStoragePath, Locations.Originals);
   await Promise.all(
     (await fsPromise.readdir(purgeDir)).map(async fileName => await purgeFile(path.join(purgeDir, fileName))),
   );

--- a/src/Trigger.ts
+++ b/src/Trigger.ts
@@ -133,6 +133,9 @@ export default class Trigger {
     // nothing if annotations are disabled.
     await AnnotationManager.processTrigger(fileName, this, triggeredPredictions);
 
+    // Copy the image to the originals folder
+    await LocalStorage.copyToLocalStorage(LocalStorage.Locations.Originals, fileName);
+
     // Call all the handlers for the trigger. There is no need to wait for these to finish before proceeding.
     MqttManager.processTrigger(fileName, this, triggeredPredictions);
     PushbulletManager.processTrigger(fileName, this, triggeredPredictions);

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -19,8 +19,10 @@ let httpTerminator: HttpTerminator;
 
 export function startApp(): void {
   const annotatedImagePath = path.join(LocalStorageManager.localStoragePath, LocalStorageManager.Locations.Annotations);
+  const originalsImagePath = path.join(LocalStorageManager.localStoragePath, LocalStorageManager.Locations.Originals);
   app.use("/", express.static(annotatedImagePath));
   app.use("/annotations", express.static(annotatedImagePath));
+  app.use("/originals", express.static(originalsImagePath));
   app.use("/motion", motionRouter);
   app.use("/statistics", statisticsRouter);
 


### PR DESCRIPTION
Fixes #350

## Description of changes

- Add support for an `originals` folder on the web server that serves up the original images received for processing. Only images that caused a trigger to fire will get stored to save space.

## Checklist

If your change touches anything under src or the README.md file these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
