### PR TITLE
Fix uri encoding

### DIFF
--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -41,6 +41,17 @@ describe("helpers", () => {
     expect(actualSettings).toEqual({ foo: "bar" });
   });
 
+  test("Verify can load settings.json with secrets that are urls", () => {
+    const secrets = { someSecret: "http://127.0.0.1:5000/" };
+    writeFileSync(secretsFilePath, JSON.stringify(secrets));
+    const settings = { foo: "{{someSecret}}" };
+    writeFileSync(settingsFilePath, JSON.stringify(settings));
+
+    const actualSettings = helpers.readSettings(serviceName, settingsFilePath, secretsFilePath);
+
+    expect(actualSettings).toEqual({ foo: "http://127.0.0.1:5000/" });
+  });
+
   test("Verify secret is rendered empty if it doesn't exist'", () => {
     const secrets = {};
     writeFileSync(secretsFilePath, JSON.stringify(secrets));


### PR DESCRIPTION
# Fixes https://github.com/danecreekphotography/node-deepstackai-trigger/issues/371

## Description of changes

When I have a secret with a uri in it, it has problems. Here is what the log shows:

`trigger_1           | 2020-10-27T10:16:49-05:00 [Trigger House East Cat/Dog detector] Error: Failed to call DeepStack at http:&#x2F;&#x2F;deepstack-ai:5000&#x2F;: Error: Invalid URI "http:///&/v1/vision/detection"`

I wrote a test that I think identifies the issue. However I may be wrong. Essentially `http://127.0.0.1:5000/` becomes `http:&#x2F;&#x2F;127.0.0.1:5000&#x2F;` and that seems to be a problem. I'm not sure why this would be a problem.

On a side note, when my secret is a username or password it seems to work fine; also note my usernames and passwords do not have special characters in it.

## Checklist

- [ ] User-facing change description added to unreleased section of CHANGELOG.md
