### PR TITLE
Fix uri encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 5.4.0
+
+- Mustache templating now works in settings.json and triggers.json, secrets are pulled from secrets.json. See the wiki for more thorough documentation.
+
 ## 5.3.1
 
 - File watching now works on Macs when the folder of images is a mounted network share. Resolves [issue 362](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/362).

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -11,6 +11,7 @@ import IPushbulletManagerConfigJson from "./handlers/pushbulletManager/IPushbull
 import IPushoverManagerConfigJson from "./handlers/pushoverManager/IPushoverManagerConfigJson";
 import ISettingsConfigJson from "./types/ISettingsConfigJson";
 import ITelegramManagerConfigJson from "./handlers/telegramManager/ITelegramManagerConfigJson";
+import IConfiguration from "./types/IConfiguration";
 
 export let awaitWriteFinish: boolean;
 export let deepstackUri: string;
@@ -27,24 +28,28 @@ export let telegram: ITelegramManagerConfigJson;
 export let verbose: boolean;
 
 /**
- * Takes a path to a configuration file and loads all of the triggers from it.
- * @param configFilePath The path to the configuration file
- * @returns The path to the loaded configuration file
+ * Takes an object with a path to a configuration file and path to a secrets file and loads all of the settings from it.
+ * @param configurations A configuration object with the path to the configuration file and path to the secrets file
+ * @returns A configuration object with path to the loaded configuration file and path to the loaded secrets file
  */
-export function loadConfiguration(configFilePaths: string[]): string {
+export function loadConfiguration(configurations: IConfiguration[]): IConfiguration {
   let settingsConfigJson: ISettingsConfigJson;
-  let loadedSettingsFilePath: string;
+  let loadedConfiguration: IConfiguration;
 
   // Look through the list of possible loadable config files and try loading
   // them in turn until a valid one is found.
-  configFilePaths.some(configFilePath => {
-    settingsConfigJson = helpers.readSettings<ISettingsConfigJson>("Settings", configFilePath);
+  configurations.some(configuration => {
+    settingsConfigJson = helpers.readSettings<ISettingsConfigJson>(
+      "Settings",
+      configuration.baseFilePath,
+      configuration.secretsFilePath,
+    );
 
     if (!settingsConfigJson) {
       return false;
     }
 
-    loadedSettingsFilePath = configFilePath;
+    loadedConfiguration = configuration;
     return true;
   });
 
@@ -69,7 +74,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
   telegram = settingsConfigJson.telegram;
   verbose = settingsConfigJson.verbose ?? false;
 
-  log.info("Settings", `Loaded settings from ${loadedSettingsFilePath}`);
+  log.info("Settings", `Loaded settings from ${loadedConfiguration.baseFilePath}`);
 
-  return loadedSettingsFilePath;
+  return loadedConfiguration;
 }

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -17,6 +17,7 @@ import TelegramConfig from "./handlers/telegramManager/TelegramConfig";
 import Trigger from "./Trigger";
 import WebRequestConfig from "./handlers/webRequest/WebRequestConfig";
 import ITriggerStatistics from "./types/ITriggerStatistics";
+import IConfiguration from "./types/IConfiguration";
 
 /**
  * Provides a running total of the number of times an image caused triggers
@@ -40,8 +41,8 @@ export let triggers: Trigger[];
  * @param configFilePath The path to the configuration file
  * @returns The path to the loaded configuration file
  */
-export function loadConfiguration(configFilePaths: string[]): string {
-  let loadedConfigFilePath: string;
+export function loadConfiguration(configurations: IConfiguration[]): IConfiguration {
+  let loadedConfiguration: IConfiguration;
   let triggerConfigJson: ITriggerConfigJson;
 
   // Reset triggers to empty in case this is getting hot reloaded
@@ -49,14 +50,18 @@ export function loadConfiguration(configFilePaths: string[]): string {
 
   // Look through the list of possible loadable config files and try loading
   // them in turn until a valid one is found.
-  configFilePaths.some(configFilePath => {
-    triggerConfigJson = helpers.readSettings<ITriggerConfigJson>("Triggers", configFilePath);
+  configurations.some(configuration => {
+    triggerConfigJson = helpers.readSettings<ITriggerConfigJson>(
+      "Triggers",
+      configuration.baseFilePath,
+      configuration.secretsFilePath,
+    );
 
     if (!triggerConfigJson) {
       return false;
     }
 
-    loadedConfigFilePath = configFilePath;
+    loadedConfiguration = configuration;
     return true;
   });
 
@@ -68,7 +73,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
     );
   }
 
-  log.info("Triggers", `Loaded configuration from ${loadedConfigFilePath}`);
+  log.info("Triggers", `Loaded configuration from ${loadedConfiguration.baseFilePath}`);
 
   triggers = triggerConfigJson.triggers.map(triggerJson => {
     log.info("Triggers", `Loaded configuration for ${triggerJson.name}`);
@@ -110,7 +115,7 @@ export function loadConfiguration(configFilePaths: string[]): string {
     return configuredTrigger;
   });
 
-  return loadedConfigFilePath;
+  return loadedConfiguration;
 }
 
 /**

--- a/src/types/IConfiguration.ts
+++ b/src/types/IConfiguration.ts
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Neil Enns. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export default interface IConfiguration {
+  baseFilePath: string;
+  secretsFilePath: string;
+}

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -3,25 +3,25 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { closeSync, existsSync, openSync, unlinkSync, writeFileSync } from "fs";
-import * as JSONC from "jsonc-parser";
 import * as helpers from "./../src/helpers";
 
 describe("helpers", () => {
+  const serviceName = "Settings";
   const settingsFilePath = `${__dirname}/settings.json`;
+  const secretsFilePath = `${__dirname}/secrets.json`;
+  //eslint-disable-next-line no-console
+  console.log = jest.fn();
 
   beforeEach(() => {
     closeSync(openSync(settingsFilePath, "w"));
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
-    if (existsSync(settingsFilePath)) {
-      unlinkSync(settingsFilePath);
-    }
+    existsSync(settingsFilePath) && unlinkSync(settingsFilePath);
+    existsSync(secretsFilePath) && unlinkSync(secretsFilePath);
   });
 
   test("Verify can load settings.json", () => {
-    const serviceName = "Settings";
     const expectedSettings = { foo: "bar" };
     writeFileSync(settingsFilePath, JSON.stringify(expectedSettings));
 
@@ -30,23 +30,56 @@ describe("helpers", () => {
     expect(actualSettings).toEqual(expectedSettings);
   });
 
+  test("Verify can load settings.json with secrets", () => {
+    const secrets = { someSecret: "bar" };
+    writeFileSync(secretsFilePath, JSON.stringify(secrets));
+    const settings = { foo: "{{someSecret}}" };
+    writeFileSync(settingsFilePath, JSON.stringify(settings));
+
+    const actualSettings = helpers.readSettings(serviceName, settingsFilePath, secretsFilePath);
+
+    expect(actualSettings).toEqual({ foo: "bar" });
+  });
+
+  test("Verify secret is rendered empty if it doesn't exist'", () => {
+    const secrets = {};
+    writeFileSync(secretsFilePath, JSON.stringify(secrets));
+    const settings = { foo: "{{someSecret}}" };
+    writeFileSync(settingsFilePath, JSON.stringify(settings));
+
+    const actualSettings = helpers.readSettings(serviceName, settingsFilePath, secretsFilePath);
+
+    expect(actualSettings).toEqual({ foo: "" });
+  });
+
   test("Verify cannot load settings.json because it does not exist", () => {
-    //eslint-disable-next-line no-console
-    console.log = jest.fn();
-    const serviceName = "Settings";
     unlinkSync(settingsFilePath);
+
+    try {
+      helpers.readSettings(serviceName, settingsFilePath);
+    } catch (error) {
+      //eslint-disable-next-line no-console
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(`[${serviceName}] Unable to read the settings file: ENOENT: no such file or directory`),
+      );
+      expect(error.message).toBe(`[${serviceName}] Unable to load file ${settingsFilePath}.`);
+    }
+  });
+
+  test("Verify cannot load secrets.json because it does not exist", () => {
+    const expectedSettings = { foo: "bar" };
+    writeFileSync(settingsFilePath, JSON.stringify(expectedSettings));
 
     const actualSettings = helpers.readSettings(serviceName, settingsFilePath);
 
     //eslint-disable-next-line no-console
     expect(console.log).toHaveBeenCalledWith(
-      expect.stringContaining("[Settings] Unable to read the configuration file: ENOENT: no such file or directory"),
+      expect.stringContaining(`[${serviceName}] Unable to read the secrets file: ENOENT: no such file or directory`),
     );
-    expect(actualSettings).toBeNull();
+    expect(actualSettings).toEqual(expectedSettings);
   });
 
-  test("Verify throws if rawConfig empty", () => {
-    const serviceName = "Settings";
+  test("Verify throws if settings.json empty", () => {
     const expectedSettings = "";
     writeFileSync(settingsFilePath, expectedSettings);
 
@@ -55,67 +88,14 @@ describe("helpers", () => {
     }).toThrow(Error);
   });
 
-  test("Verify throws with message if rawConfig empty", () => {
-    const serviceName = "Settings";
+  test("Verify throws with message if settings.json empty", () => {
     const expectedSettings = "";
     writeFileSync(settingsFilePath, expectedSettings);
 
     try {
       helpers.readSettings(serviceName, settingsFilePath);
     } catch (error) {
-      expect(error.message).toBe(`[${serviceName}] Unable to load configuration file ${settingsFilePath}.`);
-    }
-  });
-
-  test("Verify throws if json invalid", () => {
-    const serviceName = "Settings";
-    const expectedSettings = {};
-    writeFileSync(settingsFilePath, JSON.stringify(expectedSettings));
-    const mockAddListener = jest.spyOn(JSONC, "parse");
-    mockAddListener.mockImplementation((rawConfig, parseErrors) => {
-      parseErrors.push({
-        error: 1,
-        offset: 2,
-        length: 3,
-      });
-      return {};
-    });
-
-    expect(() => {
-      helpers.readSettings(serviceName, settingsFilePath);
-    }).toThrow(Error);
-  });
-
-  test("Verify throws with message if json invalid", () => {
-    const serviceName = "Settings";
-    const expectedSettings = {};
-    writeFileSync(settingsFilePath, JSON.stringify(expectedSettings));
-    const mockAddListener = jest.spyOn(JSONC, "parse");
-    const parseError1 = {
-      error: 1,
-      offset: 2,
-      length: 3,
-    };
-    const parseError2 = {
-      error: 3,
-      offset: 2,
-      length: 1,
-    };
-    mockAddListener.mockImplementation((rawConfig, parseErrors) => {
-      parseErrors.push(parseError1);
-      parseErrors.push(parseError2);
-      return {};
-    });
-    //eslint-disable-next-line no-console
-    console.log = jest.fn();
-
-    try {
-      helpers.readSettings(serviceName, settingsFilePath);
-    } catch (error) {
-      const parseErrorsAsString = `${JSON.stringify(parseError1)} ${JSON.stringify(parseError2)}`;
-      //eslint-disable-next-line no-console
-      expect(console.log).toHaveBeenCalledWith(expect.stringContaining(`[${serviceName}] ${parseErrorsAsString}`));
-      expect(error.message).toBe(`[${serviceName}] Unable to load configuration file: ${parseErrorsAsString}`);
+      expect(error.message).toBe(`[${serviceName}] Unable to load file ${settingsFilePath}.`);
     }
   });
 });

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -41,6 +41,17 @@ describe("helpers", () => {
     expect(actualSettings).toEqual({ foo: "bar" });
   });
 
+  test("Verify can load settings.json with secrets that are urls", () => {
+    const secrets = { someSecret: "http://127.0.0.1:5000/" };
+    writeFileSync(secretsFilePath, JSON.stringify(secrets));
+    const settings = { foo: "{{{someSecret}}}" };
+    writeFileSync(settingsFilePath, JSON.stringify(settings));
+
+    const actualSettings = helpers.readSettings(serviceName, settingsFilePath, secretsFilePath);
+
+    expect(actualSettings).toEqual({ foo: "http://127.0.0.1:5000/" });
+  });
+
   test("Verify secret is rendered empty if it doesn't exist'", () => {
     const secrets = {};
     writeFileSync(secretsFilePath, JSON.stringify(secrets));


### PR DESCRIPTION
# Fixes https://github.com/danecreekphotography/node-deepstackai-trigger/issues/371

## Description of changes

When I have a secret with a uri in it, it has problems. Here is what the log shows:

`trigger_1           | 2020-10-27T10:16:49-05:00 [Trigger House East Cat/Dog detector] Error: Failed to call DeepStack at http:&#x2F;&#x2F;deepstack-ai:5000&#x2F;: Error: Invalid URI "http:///&/v1/vision/detection"`

I wrote a test that I think identifies the issue. However I may be wrong. Essentially `http://127.0.0.1:5000/` becomes `http:&#x2F;&#x2F;127.0.0.1:5000&#x2F;` and that seems to be a problem. I'm not sure why this would be a problem.

On a side note, when my secret is a username or password it seems to work fine; also note my usernames and passwords do not have special characters in it.

## Checklist

- [ ] User-facing change description added to unreleased section of CHANGELOG.md
