### PR TITLE
Add support for custom Deepstack models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Add support for `customEndpoint` on a trigger to support custom Deepstack models. Resolves [issue 416](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/416).
+
 ## 5.6.1
 
 - Address a minor security vulnerability in a dependency. Resolves [issue 407](https://github.com/danecreekphotography/node-deepstackai-trigger/issues/407).

--- a/src/DeepStack.ts
+++ b/src/DeepStack.ts
@@ -9,15 +9,19 @@ import * as Settings from "./Settings";
 import request from "request-promise-native";
 import IDeepStackResponse from "./types/IDeepStackResponse";
 
-export default async function analyzeImage(fileName: string): Promise<IDeepStackResponse> {
+export default async function analyzeImage(fileName: string, endpoint?: string): Promise<IDeepStackResponse> {
   // This method of calling DeepStack comes from https://nodejs.deepstack.cc/
   const imageStream = fs.createReadStream(fileName);
   const form = { image: imageStream };
 
+  const deepstackUri = endpoint
+    ? new URL(endpoint, Settings.deepstackUri)
+    : new URL("/v1/vision/detection", Settings.deepstackUri);
+
   const rawResponse = await request
     .post({
       formData: form,
-      uri: new URL("/v1/vision/detection", Settings.deepstackUri).toString(),
+      uri: deepstackUri.toString(),
     })
     .catch(e => {
       throw Error(`Failed to call DeepStack at ${Settings.deepstackUri}: ${e.error}`);

--- a/src/TriggerManager.ts
+++ b/src/TriggerManager.ts
@@ -78,6 +78,7 @@ export function loadConfiguration(configurations: IConfiguration[]): IConfigurat
   triggers = triggerConfigJson.triggers.map(triggerJson => {
     log.info("Triggers", `Loaded configuration for ${triggerJson.name}`);
     const configuredTrigger = new Trigger({
+      customEndpoint: triggerJson.customEndpoint,
       cooldownTime: triggerJson.cooldownTime,
       enabled: triggerJson.enabled ?? true, // If it isn't specified then enable the camera
       name: triggerJson.name,

--- a/src/schemas/triggerConfiguration.schema.json
+++ b/src/schemas/triggerConfiguration.schema.json
@@ -25,7 +25,7 @@
         "description": "A trigger that responds to DeepStack predictions.",
         "type": "object",
         "anyOf": [{ "required": ["watchPattern"] }, { "required": ["snapshotUri"] }],
-        "oneOf": [{ "required": ["watchPattern"] }, { "required": ["customEndpoint"] }],
+        "oneOf": [{ "required": ["watchObjects"] }, { "required": ["customEndpoint"] }],
         "required": ["handlers", "name"],
         "additionalProperties": false,
         "properties": {

--- a/src/schemas/triggerConfiguration.schema.json
+++ b/src/schemas/triggerConfiguration.schema.json
@@ -24,9 +24,11 @@
         "title": "Trigger",
         "description": "A trigger that responds to DeepStack predictions.",
         "type": "object",
-        "anyOf": [{ "required": ["watchPattern"] }, { "required": ["snapshotUri"] }],
-        "oneOf": [{ "required": ["watchObjects"] }, { "required": ["customEndpoint"] }],
-        "required": ["handlers", "name"],
+        "allOf": [
+          { "anyOf": [{ "required": ["watchPattern"] }, { "required": ["snapshotUri"] }] },
+          { "oneOf": [{ "required": ["watchObjects"] }, { "required": ["customEndpoint"] }] },
+          { "required": ["handlers", "name"] }
+        ],
         "additionalProperties": false,
         "properties": {
           "name": {

--- a/src/schemas/triggerConfiguration.schema.json
+++ b/src/schemas/triggerConfiguration.schema.json
@@ -45,6 +45,11 @@
             "maximum": 600,
             "type": "integer"
           },
+          "customEndpoint": {
+            "description": "Custom endpoint for DeepStack, used to call a custom model. When specified watchObjects is ignored.",
+            "examples": ["/v1/vision/custom/my_custom_model_name?image"],
+            "type": "string"
+          },
           "enabled": {
             "description": "Set to true to enable the trigger. If false the trigger will be ignored.",
             "examples": [true],

--- a/src/schemas/triggerConfiguration.schema.json
+++ b/src/schemas/triggerConfiguration.schema.json
@@ -25,7 +25,8 @@
         "description": "A trigger that responds to DeepStack predictions.",
         "type": "object",
         "anyOf": [{ "required": ["watchPattern"] }, { "required": ["snapshotUri"] }],
-        "required": ["handlers", "name", "watchObjects"],
+        "oneOf": [{ "required": ["watchPattern"] }, { "required": ["customEndpoint"] }],
+        "required": ["handlers", "name"],
         "additionalProperties": false,
         "properties": {
           "name": {

--- a/src/types/ITriggerJson.ts
+++ b/src/types/ITriggerJson.ts
@@ -11,6 +11,7 @@ import IPushbulletConfigJson from "../handlers/pushbulletManager/IPushoverConfig
 
 export default interface ITriggerJson {
   cooldownTime: number;
+  customEndpoint?: string;
   enabled: boolean;
   name: string;
   snapshotUri: string;


### PR DESCRIPTION
# Fixes #416

## Description of changes

- Add an optional `customEndpoint` property to the trigger configuration
- Update the schema to require either `customEndpoint` or `watchObjects` but not both
- Use the `customEndpoint` property when calling Deepstack if it is specified, and skip checking `watchObjects` when it is included
- 
## Checklist

If your change touches anything under src or the README.md file
these items must be done:

- [X] User-facing change description added to unreleased section of CHANGELOG.md
